### PR TITLE
Patch for Water Dragon of Cera Lake

### DIFF
--- a/Fully Translated/gmd_59.csv
+++ b/Fully Translated/gmd_59.csv
@@ -2576,7 +2576,7 @@ rest.",ui\00_message\master\area21_spot_info.gmd,\ui\uGUIAreaMaster.arc,uGUIArea
 99,namedparam_223,オッドの精鋭, Odd's Elite ,ui\00_message\named\named_param.gmd,\ui\gui_cmn.arc,gui_cmn.arc,99
 100,namedparam_224,盾破りのオッド, Odd the Shield-Breaker ,ui\00_message\named\named_param.gmd,\ui\gui_cmn.arc,gui_cmn.arc,100
 101,namedparam_225,レイクニュート, Lake Newt ,ui\00_message\named\named_param.gmd,\ui\gui_cmn.arc,gui_cmn.arc,101
-102,namedparam_226,セラー湖の水竜, Water Dragon of Cellar Lake ,ui\00_message\named\named_param.gmd,\ui\gui_cmn.arc,gui_cmn.arc,102
+102,namedparam_226,セラー湖の水竜, Water Dragon of Cera Lake ,ui\00_message\named\named_param.gmd,\ui\gui_cmn.arc,gui_cmn.arc,102
 103,namedparam_227,葉影の密猟者, Shadow Poacher ,ui\00_message\named\named_param.gmd,\ui\gui_cmn.arc,gui_cmn.arc,103
 104,namedparam_228,密猟者の護衛, Poacher Guard ,ui\00_message\named\named_param.gmd,\ui\gui_cmn.arc,gui_cmn.arc,104
 105,namedparam_229,忘れられた亡霊, Forgotten Specter ,ui\00_message\named\named_param.gmd,\ui\gui_cmn.arc,gui_cmn.arc,105


### PR DESCRIPTION
Dragon was originally named Water Dragon of Cellar Lake, updated name with reference to nearby geography.