### PR TITLE
Minor Dailogue fixes

### DIFF
--- a/Fully Translated/gmd_66.csv
+++ b/Fully Translated/gmd_66.csv
@@ -224,7 +224,7 @@ We'd hate for you to forget something.
 Please check before you leave!",ui\00_message\npc\base\n1039.gmd,\npc\n1039.arc,n1039.arc,3
 0,,"白竜様は休養中である
 むやみに触れる、用もなく話しかけるなど
-無礼は慎むように","Master Hakuryu is resting.
+無礼は慎むように","Lord White Dragon is resting.
 Please refrain from touching him unnecessarily,
 talking to him without his business, etc.
 Please refrain from rudeness.",ui\00_message\npc\base\n1040.gmd,\npc\n1040.arc,n1040.arc,0
@@ -355,8 +355,8 @@ How divine, how deeply moving it is!",ui\00_message\npc\base\n1042.gmd,\npc\n104
 白竜様に敗れ墜ちた金色の竜は
 その後どうなったのでしょうね","But aren't you curious?
 I wonder what happened to the golden dragon 
-that was defeated and crashed by Master 
-Hakuryu after that?",ui\00_message\npc\base\n1042.gmd,\npc\n1042.arc,n1042.arc,5
+that was defeated by the Lord 
+White Dragon after that?",ui\00_message\npc\base\n1042.gmd,\npc\n1042.arc,n1042.arc,5
 0,,"良き旅には良き仲間、良き試練
 そして良き歌を！","A good journey, good friends, good trials
 and good songs!",ui\00_message\npc\base\n1042.gmd,\npc\n1042.arc,n1042.arc,6
@@ -399,8 +399,8 @@ How divine, how deeply moving it is!",ui\00_message\npc\base\n1042.gmd,\npc\n104
 白竜様に敗れ墜ちた金色の竜は
 その後どうなったのでしょうね","But aren't you curious?
 I wonder what happened to the golden dragon 
-that was defeated and crashed by Master 
-Hakuryu after that?",ui\00_message\npc\base\n1042.gmd,\npc\n1042.arc,n1042.arc,5
+that was defeated by the Lord 
+White Dragon after that?",ui\00_message\npc\base\n1042.gmd,\npc\n1042.arc,n1042.arc,5
 0,,"良き旅には良き仲間、良き試練
 そして良き歌を！","A good journey, good friends, good trials
 and good songs!",ui\00_message\npc\base\n1042.gmd,\npc\n1042.arc,n1042.arc,6

--- a/Fully Translated/gmd_67.csv
+++ b/Fully Translated/gmd_67.csv
@@ -497,10 +497,9 @@ status of
 in the Mysree Forest.",ui\00_message\npc\base\n1412.gmd,\npc\n1412.arc,n1412.arc,32
 0,,"白竜様の力が衰えてから
 森のいたるところで魔物や獣たちが
-凶暴化してきているの","Since Master Hakuryu's power waned,
+凶暴化してきているの","Since the Lord White Dragon's power waned,
 demons and beasts everywhere in the forest have
-become
-more ferocious.",ui\00_message\npc\base\n1412.gmd,\npc\n1412.arc,n1412.arc,33
+become more ferocious.",ui\00_message\npc\base\n1412.gmd,\npc\n1412.arc,n1412.arc,33
 0,,"今は、各所で起こった異変に
 順番に対処するしかないという状況よ
 特に、洞窟や水辺には注意して","Right now, we're just dealing with the anomalies

--- a/splits/gmd_94.csv
+++ b/splits/gmd_94.csv
@@ -330,7 +330,7 @@ greatest sword this time.",ui\00_message\quest\q60000011.gmd,\quest\q60000011.ar
 その使命を全うする者のことだ",An Arisen faces trials without fear and fulfills their duty,ui\00_message\quest\q60000011.gmd,\quest\q60000011.arc,q60000011.arc,22
 0,,"与えられた試練を全てこなせた者のみ
 《魔弓の証》を得ることができる","Only those who complete all trials
-may obtain the 《Element Archer's Mark.》",ui\00_message\quest\q60000011.gmd,\quest\q60000011.arc,q60000011.arc,23
+may obtain the 《Alchemist's Mark.》",ui\00_message\quest\q60000011.gmd,\quest\q60000011.arc,q60000011.arc,23
 0,,"各試練のやり方について
 わからなければ今までの得た知識を
 確認しながら臨むがいい","If unsure about any trial, review the knowledge you've gained so far",ui\00_message\quest\q60000011.gmd,\quest\q60000011.arc,q60000011.arc,24


### PR DESCRIPTION
-Fixes instance of "《Element Archer's Mark.》" showing up in the Alchemists Job Trial Dialogue 
-Fixes instances of Hakuryu showing up in dialogue to Lord White Dragon and adding addition lines to make more sense with that name. 
-Removed a few redundant lines when describing the fight between the white dragon and golden dragon.