### PR TITLE
speech bubble recovery

### DIFF
--- a/splits/257.csv
+++ b/splits/257.csv
@@ -417,95 +417,95 @@ phrase. You can purchase it in the online shop",ui\00_message\ui\simple_communic
 153,simple_text_9112,/d additem 17103 1 1,/d additem 17103 1 1,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,153
 154,simple_text_9113,/d additem 17104 1 1,/d additem 17104 1 1,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,154
 155,simple_text_9114,/d additem 17153 1 1,/d additem 17153 1 1,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,155
-156,simple_text_9115,やりましょう！,Let's do it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,156
-157,simple_text_9116,いきましょう！,Let's go!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,157
-158,simple_text_9117,楽しかった！,It was fun!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,158
-159,simple_text_9118,すごい！,Amazing!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,159
-160,simple_text_9119,すばらしい！,Wonderful!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,160
-161,simple_text_9120,グッジョブ！,Good job!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,161
-162,simple_text_9121,さすが！,As expected!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,162
-163,simple_text_9122,ナイスです！,Nice!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,163
-164,simple_text_9123,気にしないで！,Don't worry about it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,164
-165,simple_text_9124,お気になさらず,I don't mind.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,165
-166,simple_text_9125,それではまた！,"Well, see you!",ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,166
-167,simple_text_9126,次こそは！,Next time!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,167
-168,simple_text_9127,ザコは無視しますか？,Ignore it?,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,168
-169,simple_text_9128,いいですね！,That's excellent!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,169
-170,simple_text_9129,了解！,Understood!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,170
-171,simple_text_9130,無理です！,That's unreasonable!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,171
-172,simple_text_9131,マーカーを目指しましょう,Head for the marker,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,172
-173,simple_text_9132,帰還しましょう,Let's return,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,173
-174,simple_text_9133,拠点に行きましょう,Let's head towards the base,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,174
-175,simple_text_9134,リム転移します,Let's transfer at the Riftstone,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,175
-176,simple_text_9135,装備を変えます,Changing equipment,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,176
-177,simple_text_9136,ジョブを変えます,Changing job,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,177
-178,simple_text_9137,アイテムを補充します,Replenishing items,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,178
-179,simple_text_9138,アイテムを取ります！,Harvesting items!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,179
-180,simple_text_9139,アイテムがいっぱいになりました,Items have been filled,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,180
-181,simple_text_9140,もう一度行きませんか？,Are we not going again?,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,181
-182,simple_text_9141,離脱します！,Withdrawing!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,182
-183,simple_text_9142,リーダーを変更します,Changing leader,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,183
-184,simple_text_9143,どんまい！,Don't fret!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,184
-185,simple_text_9144,気にするな！,Never mind it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,185
-186,simple_text_9145,気にしないで！,Don't worry about it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,186
-187,simple_text_9146,大丈夫です！,It's okay!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,187
-188,simple_text_9147,申し訳ない！,I'm sorry!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,188
-189,simple_text_9148,すみません！,Pardon me!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,189
-190,simple_text_9149,俺が！,Me!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,190
-191,simple_text_9150,私が！,I!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,191
-192,simple_text_9151,状態異常に気を付けましょう！,Let's debilitate it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,192
-193,simple_text_9152,エンチャントを頼む！,Requesting an enchantment!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,193
-194,simple_text_9153,エンチャントをお願い！,Please enchant!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,194
-195,simple_text_9154,ザコは無視しよう！,Ignore it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,195
-196,simple_text_9155,ザコは無視しましょう！,Ignoring it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,196
-197,simple_text_9156,この敵は倒そう！,Kill this enemy!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,197
-198,simple_text_9157,この敵は倒しましょう！,Let's kill this enemy!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,198
-199,simple_text_9158,先に行ってください,Please go ahead,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,199
-200,simple_text_9189,急ごう！,Hurry!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,200
-201,simple_text_9190,急ぎましょう！,Make haste!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,201
-202,simple_text_9191,焦らずに,Steady...,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,202
-203,simple_text_9192,助かりました！,Rescued!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,203
-204,simple_text_9193,う、動けない！,I... I cannot move!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,204
-205,simple_text_9194,少し準備します,Preparing a bit,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,205
-206,simple_text_9195,手を出すな,Hand it in,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,206
-207,simple_text_9196,手を出さないで,Do not hand it in,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,207
-208,simple_text_9197,敵を引きつける,Attract the enemy,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,208
-209,simple_text_9198,敵を引きつけます,Drawing enemy over,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,209
-210,simple_text_9199,俺に任せろ！,Leave it to me!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,210
-211,simple_text_9200,私に任せて！,Entrust it to me!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,211
-212,simple_text_9201,俺の背中に隠れて！,I'll hide on the back!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,212
-213,simple_text_9202,私の背中に隠れて！,I'll conceal myself on the back!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,213
-214,simple_text_9203,凍らせる！,Can Freeze!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,214
-215,simple_text_9204,凍らせます！,Able to Freeze!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,215
-216,simple_text_9205,スローにする！,Slowing it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,216
-217,simple_text_9206,スローにします！,I'll slow it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,217
-218,simple_text_9207,眠らせる！,Can put it to sleep!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,218
-219,simple_text_9208,眠らせます！,Able to put it to sleep!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,219
-220,simple_text_9209,状態異常を狙う！,Debilitate it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,220
-221,simple_text_9210,状態異常を狙います！,Aim debilitations at it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,221
-222,simple_text_9211,状態異常にする！,Can debilitate it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,222
-223,simple_text_9212,状態異常にします！,Debilitating it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,223
-224,simple_text_9213,弱点を攻撃してくれ！,Attack its weak spot!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,224
-225,simple_text_9214,弱点を攻撃して！,Strike at its weak point!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,225
-226,simple_text_9215,別れて戦おう！,Spread out and attack!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,226
-227,simple_text_9216,別れて戦いましょう！,Split up and fight!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,227
-228,simple_text_9217,集まってください！,Gather together!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,228
-229,simple_text_9218,散らばってください！,Please spread out!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,229
-230,simple_text_9219,弱点を出そう！,Reveal its weak spot!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,230
-231,simple_text_9220,弱点を狙おう！,Aim for its weak spot!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,231
-232,simple_text_9221,弱点を攻撃しよう！,Attack its weakspot!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,232
-233,simple_text_9222,スタミナを減らそう！,Decrease its stamina!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,233
-234,simple_text_9223,一気に揺さぶろう！,Shake it without stopping!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,234
-235,simple_text_9224,今助ける！,I'll aid you at once!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,235
-236,simple_text_9225,今助けます！,I'll assist you!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,236
-237,simple_text_9226,こっちだ、跳ね上げる！,"Over here, jump!",ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,237
-238,simple_text_9227,こっちです、跳ね上げます！,"This way, leap!",ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,238
-239,simple_text_9228,おきろ！,Get up!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,239
-240,simple_text_9229,起きて！,Rise!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,240
-241,simple_text_9230,トドメだ！,Take that!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,241
-242,simple_text_9231,仕切り直そう！,We'll redo that!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,242
-243,simple_text_9232,仕切り直しましょう！,Let's go back and start again!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,243
-244,simple_text_9233,こいつは危険です！,You're in danger!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,244
+156,simple_text_9115,やりましょう！,Let's do it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,156
+157,simple_text_9116,いきましょう！,Let's go!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,157
+158,simple_text_9117,楽しかった！,That was fun!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,158
+159,simple_text_9118,すごい！,Amazing!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,159
+160,simple_text_9119,すばらしい！,Wonderful!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,160
+161,simple_text_9120,グッジョブ！,Good job!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,161
+162,simple_text_9121,さすが！,As expected!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,162
+163,simple_text_9122,ナイスです！,Nice!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,163
+164,simple_text_9123,気にしないで！,Don't worry about it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,164
+165,simple_text_9124,お気になさらず,I don't mind.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,165
+166,simple_text_9125,それではまた！,Well, see you!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,166
+167,simple_text_9126,次こそは！,Next time!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,167
+168,simple_text_9127,ザコは無視しますか？,Ignore it?,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,168
+169,simple_text_9128,いいですね！,That's excellent!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,169
+170,simple_text_9129,了解！,Understood!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,170
+171,simple_text_9130,無理です！,That's unreasonable!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,171
+172,simple_text_9131,マーカーを目指しましょう,Let's head for the marker.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,172
+173,simple_text_9132,帰還しましょう,Let's return.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,173
+174,simple_text_9133,拠点に行きましょう,Let's head towards the base.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,174
+175,simple_text_9134,リム転移します,Let's transfer at the Riftstone.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,175
+176,simple_text_9135,装備を変えます,Changing equipment.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,176
+177,simple_text_9136,ジョブを変えます,Switching Vocation.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,177
+178,simple_text_9137,アイテムを補充します,Replenishing items.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,178
+179,simple_text_9138,アイテムを取ります！,Harvesting items!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,179
+180,simple_text_9139,アイテムがいっぱいになりました,Items have been restocked.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,180
+181,simple_text_9140,もう一度行きませんか？,Are we not going again?,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,181
+182,simple_text_9141,離脱します！,Withdrawing!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,182
+183,simple_text_9142,リーダーを変更します,Changing leader.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,183
+184,simple_text_9143,どんまい！,It's okay!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,184
+185,simple_text_9144,気にするな！,Don't fret!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,185
+186,simple_text_9145,気にしないで！,Don't worry about it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,186
+187,simple_text_9146,大丈夫です！,It's all good!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,187
+188,simple_text_9147,申し訳ない！,Thank you very much!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,188
+189,simple_text_9148,すみません！,Pardon me!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,189
+190,simple_text_9149,俺が！,I'll do it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,190
+191,simple_text_9150,私が！,I'll do it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,191
+192,simple_text_9151,状態異常に気を付けましょう！,Let's debilitate it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,192
+193,simple_text_9152,エンチャントを頼む！,Requesting an enchantment!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,193
+194,simple_text_9153,エンチャントをお願い！,Please enchant!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,194
+195,simple_text_9154,ザコは無視しよう！,Ignore the small fry!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,195
+196,simple_text_9155,ザコは無視しましょう！,Let's ignore the small fry!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,196
+197,simple_text_9156,この敵は倒そう！,Kill this enemy!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,197
+198,simple_text_9157,この敵は倒しましょう！,Let's kill this enemy!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,198
+199,simple_text_9158,先に行ってください,Please go ahead.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,199
+200,simple_text_9189,急ごう！,Hurry!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,200
+201,simple_text_9190,急ぎましょう！,Quickly!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,201
+202,simple_text_9191,焦らずに,Steady...,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,202
+203,simple_text_9192,助かりました！,I'm saved!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,203
+204,simple_text_9193,う、動けない！,I... I cannot move!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,204
+205,simple_text_9194,少し準備します,Preparing a bit.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,205
+206,simple_text_9195,手を出すな,Don't get involved.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,206
+207,simple_text_9196,手を出さないで,Please don't get involved.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,207
+208,simple_text_9197,敵を引きつける,Attract the enemy.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,208
+209,simple_text_9198,敵を引きつけます,Drawing the enemy over.,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,209
+210,simple_text_9199,俺に任せろ！,Leave it to me!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,210
+211,simple_text_9200,私に任せて！,Leave it to me!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,211
+212,simple_text_9201,俺の背中に隠れて！,I'll hide on its back!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,212
+213,simple_text_9202,私の背中に隠れて！,I'll hide on its back!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,213
+214,simple_text_9203,凍らせる！,Freeze it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,214
+215,simple_text_9204,凍らせます！,We can freeze it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,215
+216,simple_text_9205,スローにする！,Slowing it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,216
+217,simple_text_9206,スローにします！,I'll slow it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,217
+218,simple_text_9207,眠らせる！,Put it to sleep!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,218
+219,simple_text_9208,眠らせます！,Putting it to sleep!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,219
+220,simple_text_9209,状態異常を狙う！,Aim to debilitate it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,220
+221,simple_text_9210,状態異常を狙います！,Aiming to debilitate!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,221
+222,simple_text_9211,状態異常にする！,Debilitate it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,222
+223,simple_text_9212,状態異常にします！,Debilitating it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,223
+224,simple_text_9213,弱点を攻撃してくれ！,Attack the weak point!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,224
+225,simple_text_9214,弱点を攻撃して！,Strike the weak point!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,225
+226,simple_text_9215,別れて戦おう！,Spread out and attack!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,226
+227,simple_text_9216,別れて戦いましょう！,Split up and attack!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,227
+228,simple_text_9217,集まってください！,Gather together!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,228
+229,simple_text_9218,散らばってください！,Please spread out!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,229
+230,simple_text_9219,弱点を出そう！,Reveal its weak spot!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,230
+231,simple_text_9220,弱点を狙おう！,Aim for its weak spot!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,231
+232,simple_text_9221,弱点を攻撃しよう！,Attack its weakspot!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,232
+233,simple_text_9222,スタミナを減らそう！,Decrease its stamina!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,233
+234,simple_text_9223,一気に揺さぶろう！,Shake it without stopping!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,234
+235,simple_text_9224,今助ける！,I'll aid you at once!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,235
+236,simple_text_9225,今助けます！,I'll assist you!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,236
+237,simple_text_9226,こっちだ、跳ね上げる！,Over here, jump!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,237
+238,simple_text_9227,こっちです、跳ね上げます！,This way, now jump!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,238
+239,simple_text_9228,おきろ！,Get up!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,239
+240,simple_text_9229,起きて！,Stand up!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,240
+241,simple_text_9230,トドメだ！,Finish it off!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,241
+242,simple_text_9231,仕切り直そう！,We'll redo that!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,242
+243,simple_text_9232,仕切り直しましょう！,Let's go back and start again!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,243
+244,simple_text_9233,こいつは危険です！,That guy's dangerous!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,244
 0,simple_text_category_191,あいさつ,Greetings,ui\00_message\ui\simple_text_category.gmd,\ui\gui_cmn.arc,gui_cmn.arc,0
 1,simple_text_category_192,質問,Questions,ui\00_message\ui\simple_text_category.gmd,\ui\gui_cmn.arc,gui_cmn.arc,1
 2,simple_text_category_193,返答,Replies,ui\00_message\ui\simple_text_category.gmd,\ui\gui_cmn.arc,gui_cmn.arc,2


### PR DESCRIPTION
Once patched, player will be able to see the speech bubbles again in chat.
Still cannot locate the other simple_text Phrases in the repo. Perhaps they got yeeted.