### PR TITLE
Skipped lines on Phrases

### DIFF
--- a/splits/257.csv
+++ b/splits/257.csv
@@ -427,7 +427,7 @@ phrase. You can purchase it in the online shop",ui\00_message\ui\simple_communic
 163,simple_text_9122,ナイスです！,Nice!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,163,
 164,simple_text_9123,気にしないで！,Don't worry about it!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,164,
 165,simple_text_9124,お気になさらず,I don't mind,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,165,
-166,simple_text_9125,それではまた！,Well, see you!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,166
+166,simple_text_9125,それではまた！,"Well, see you!",ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,166
 167,simple_text_9126,次こそは！,Next time!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,167,
 168,simple_text_9127,ザコは無視しますか？,Ignore it?,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,168,
 169,simple_text_9128,いいですね！,That's excellent!,ui\00_message\ui\simple_text.gmd,\ui\gui_cmn.arc,gui_cmn.arc,169,

--- a/splits/270.csv
+++ b/splits/270.csv
@@ -757,7 +757,7 @@ appeared (1 min left)",ui\00_message\quest_info\q90030104_00.gmd,\quest\q9003010
 32,CHAT_COM_34,ナイスです！,Nice!,ui\00_message\simple_com\chat_com_text_01.gmd,\ui\gui_cmn.arc,gui_cmn.arc,32,
 33,CHAT_COM_35,気にしないで！,Don't worry about it!,ui\00_message\simple_com\chat_com_text_01.gmd,\ui\gui_cmn.arc,gui_cmn.arc,33,
 34,CHAT_COM_36,お気になさらず,I don't mind.,ui\00_message\simple_com\chat_com_text_01.gmd,\ui\gui_cmn.arc,gui_cmn.arc,34,
-35,CHAT_COM_37,それではまた！,Well, see you!,ui\00_message\simple_com\chat_com_text_01.gmd,\ui\gui_cmn.arc,gui_cmn.arc,35,
+35,CHAT_COM_37,それではまた！,"Well, see you!",ui\00_message\simple_com\chat_com_text_01.gmd,\ui\gui_cmn.arc,gui_cmn.arc,35,
 36,CHAT_COM_38,次こそは！,Next time!,ui\00_message\simple_com\chat_com_text_01.gmd,\ui\gui_cmn.arc,gui_cmn.arc,36,
 0,CHAT_COM_39,誰ですか？,Who?,ui\00_message\simple_com\chat_com_text_02.gmd,\ui\gui_cmn.arc,gui_cmn.arc,0,
 1,CHAT_COM_40,どちらですか？,Which?,ui\00_message\simple_com\chat_com_text_02.gmd,\ui\gui_cmn.arc,gui_cmn.arc,1,


### PR DESCRIPTION
Not only do simple_text and CHAT_COM duplicate entries have to match, apparently some of them require quotation marks to stay around them.