### PR TITLE
Formatting + Craft Menu Title

### DIFF
--- a/Fully Translated/085.csv
+++ b/Fully Translated/085.csv
@@ -1034,8 +1034,11 @@ not a soul has approached chapel since.",ui\00_message\loading\loading_message_0
 秘めた大型の錬魔も確認されたという。後に神殿を
 攻める足がかりとして準備されていた可能性がある","<COL ffdc78>A door requiring a ""Jewelry"" key.</COL>
 Another layer that continues
-from the back of the ark that fell west of Tel.
-This passage is far more dangerous than the front.
+from the back of the Ark that fell west of Tel.
+Unlike that of the front entrance,
+this level is said to contain
+large alchemical constructs that pose
+a terrible danger.
 A strange odor is present here as well.
 It's possible that this location was prepared
 as a foothold in case of attack.",ui\00_message\loading\loading_message_001.gmd,\ui\00_message\loading\loading_message_001.arc,loading_message_001.arc,3,

--- a/Fully Translated/105.csv
+++ b/Fully Translated/105.csv
@@ -803,7 +803,7 @@ Order and Arisen through him -
 though occasional direct reports do 
 happen.",ui\00_message\npc\base\n1302.gmd,\npc\n1302.arc,n1302.arc,15,Federico
 0,,"ウチは装具屋だよ
-要るものがないか見ていってよ","Hey, are you here for shopping?
+要るものがないか見ていってよ","Hey, you here to shop?
 See if there's anything you need.",ui\00_message\npc\base\n1303.gmd,\npc\n1303.arc,n1303.arc,0,Eterna
 0,,"うちがなんとかやっていけてるのも
 騎士さんや覚者さんのお陰だよ","We're scraping by thanks to the Knights...
@@ -1218,21 +1218,19 @@ returned to the bridge commonly known as the
 ""Roaring Demon Bridge"" to the east of Tel.",ui\00_message\npc\base\n1313.gmd,\npc\n1313.arc,n1313.arc,41,Alfred
 0,,"ヤツは《橋守のビンシャ》と名乗り
 東の橋を占拠し陣取っている小鬼どものリーダーだ
-見かけたらそいつを退治してくれないだろうか","He is the leader of the small demons who call
-themselves
-""Bridgekeeper Binshaw"" and have occupied and
-entrenched themselves in the eastern bridge.
-Can you defeat and get rid of them if you see
-them?",ui\00_message\npc\base\n1313.gmd,\npc\n1313.arc,n1313.arc,42,Alfred
+見かけたらそいつを退治してくれないだろうか","He is the leader of the small demons
+who call themselves the ""Bridgekeeper Binshaw""
+and have entrenched themselves
+on the eastern bridge.
+Could you get rid of them if you see them?",ui\00_message\npc\base\n1313.gmd,\npc\n1313.arc,n1313.arc,42,Alfred
 0,,"ヤツは返り討ちにした騎士や覚者から
 いくつも《グレードの高い装備》を奪っているらしい","It seems that he has taken several
 ""high-grade equipment"" from the knights and the
 Arisen he has defeated.",ui\00_message\npc\base\n1313.gmd,\npc\n1313.arc,n1313.arc,43,Alfred
 0,,"討伐できたなら、貴君がそれを
 奪い返し手に入れることもできるだろう
-頭のかたすみに留めておいてくれ","If you can subdue him, you will also be able to
-retrieve it
-and get it back.
+頭のかたすみに留めておいてくれ","If you can subdue him,
+you will also be able to retrieve it.
 Please keep that in mind.",ui\00_message\npc\base\n1313.gmd,\npc\n1313.arc,n1313.arc,44,Alfred
 0,,"村を代表して礼を言う
 貴君はテルにとって英雄だ","I will express my gratitude on behalf of the

--- a/Fully Translated/133.csv
+++ b/Fully Translated/133.csv
@@ -263,8 +263,8 @@ It wasn't as strong as I thought it would be.",ui\00_message\pw\pwtlk06.gmd,\gam
 Success! Master!",ui\00_message\pw\pwtlk06.gmd,\game_common.arc,game_common.arc,7,
 0,,"戦術育成でもっと覚者さまのこと、
 教えてほしいです！","
-I would like to learn more about you, , in
-tactical training!",ui\00_message\pw\pwtlk06.gmd,\game_common.arc,game_common.arc,135,
+I would like to learn more about you
+in tactical training!",ui\00_message\pw\pwtlk06.gmd,\game_common.arc,game_common.arc,135,
 0,,揺さぶりにいきます！,"
 I'm going to shake things up!",ui\00_message\pw\pwtlk06.gmd,\game_common.arc,game_common.arc,95,
 0,,支援しますね！,"

--- a/Fully Translated/193.csv
+++ b/Fully Translated/193.csv
@@ -402,8 +402,11 @@ but there seems to be a lack of overall energy...
 I asked a person named Henry about it indirectly, 
 but all they said was that there are 
 various things going on.",ui\00_message\quest_info\q20000009_00.gmd,\quest\q20000009.arc,q20000009.arc,3,Henry
-4,q20000009_00_887,白竜神殿の道具屋ヴァイスロットを訪ねる,"Visit Vicelot's item shop in the White Dragon
-Temple",ui\00_message\quest_info\q20000009_00.gmd,\quest\q20000009.arc,q20000009.arc,4,Henry
+4,q20000009_00_887,白竜神殿の道具屋ヴァイスロットを訪ねる,"の扉あり</COL>
+テルの西に落下したアークの裏側から続く別階層
+表側とは異なり、こちらには恐るべき危険性を
+秘めた大型の錬魔も確認されたという。後に神殿を
+Visit Vicelot's item shop in the White Dragon Temple",ui\00_message\quest_info\q20000009_00.gmd,\quest\q20000009.arc,q20000009.arc,4,Henry
 5,q20000009_00_888,神殿の外で薬の材料を入手する（残り２）,Collect the materials needed in Hidell Plains (2 left),ui\00_message\quest_info\q20000009_00.gmd,\quest\q20000009.arc,q20000009.arc,5,Henry
 7,q20000009_00_890,ヴァイスロットに届ける,Deliver the materials to Vicelot,ui\00_message\quest_info\q20000009_00.gmd,\quest\q20000009.arc,q20000009.arc,7,Henry
 8,q20000009_00_891,薬をヘンリーに届ける,Deliver the medicine to Henry,ui\00_message\quest_info\q20000009_00.gmd,\quest\q20000009.arc,q20000009.arc,8,Henry
@@ -518,8 +521,7 @@ I saw her gazing at the back of another Arisen.",ui\00_message\quest_info\q20000
 4,q20000014_00_958,＜<SQDI NAME>＞を＜<SQDI NUM>＞個、メイリーフに渡す（残り:<SQDI DNUM>）,Deliver <SQDI NAME> x<SQDI NUM> to Mayleaf (need: <SQDI DNUM>),ui\00_message\quest_info\q20000014_00.gmd,\quest\q20000014.arc,q20000014.arc,4,Mayleaf
 0,q20000015_00_224,騎士と覚者,Knight and Arisen,ui\00_message\quest_info\q20000015_00.gmd,\quest\q20000015.arc,q20000015.arc,0,Heinz
 1,q20000015_00_224,"ハインツの依頼を聞き
-対象の敵を討伐する","Listen to Heinz's request and defeat the target enemy
-",ui\00_message\quest_info\q20000015_00.gmd,\quest\q20000015.arc,q20000015.arc,1,Heinz
+対象の敵を討伐する","Listen to Heinz's request and defeat the target",ui\00_message\quest_info\q20000015_00.gmd,\quest\q20000015.arc,q20000015.arc,1,Heinz
 2,q20000015_00_224,"<NAME AREA>の何処かに
 覚者の探索能力を見込み、相談したい者がいるという","There is someone somewhere in <NAME AREA>
 who seeks the assistance of an Arisen.",ui\00_message\quest_info\q20000015_00.gmd,\quest\q20000015.arc,q20000015.arc,2,Heinz

--- a/splits/244.csv
+++ b/splits/244.csv
@@ -556,8 +556,8 @@ unavailable for acceptance due to being locked.",ui\00_message\ui\Quest_res.gmd,
 49,msg_ShopTitle_Charges49,被ダメージ軽減！,Reduced damage!,ui\00_message\ui\ShopTitleCharges_res.gmd,\ui\gui_cmn.arc,gui_cmn.arc,49,
 50,msg_ShopTitle_Charges50,耐久力UP！,Endurance UP!,ui\00_message\ui\ShopTitleCharges_res.gmd,\ui\gui_cmn.arc,gui_cmn.arc,50,
 51,msg_ShopTitle_Charges51,状態異常の蓄積軽減！,Reduction of condition accumulation!,ui\00_message\ui\ShopTitleCharges_res.gmd,\ui\gui_cmn.arc,gui_cmn.arc,51,
-52,msg_ShopTitle_Charges52,必要素材が格納チェストからも参照可能！,"You can also use required materials from Storage
-Chest!",ui\00_message\ui\ShopTitleCharges_res.gmd,\ui\gui_cmn.arc,gui_cmn.arc,52,
+52,msg_ShopTitle_Charges52,必要素材が格納チェストからも参照可能！,"You can also access required materials
+from the Storage Chest!",ui\00_message\ui\ShopTitleCharges_res.gmd,\ui\gui_cmn.arc,gui_cmn.arc,52,
 53,msg_ShopTitle_Charges53,「<OPCS>」専用ロットが利用可能！,"""<OPCS>"" exclusive lot available!",ui\00_message\ui\ShopTitleCharges_res.gmd,\ui\gui_cmn.arc,gui_cmn.arc,53,
 54,msg_ShopTitle_Charges54,<UNTN TP>加算中！,<UNTN TP> Addition in progress!,ui\00_message\ui\ShopTitleCharges_res.gmd,\ui\gui_cmn.arc,gui_cmn.arc,54,
 55,msg_ShopTitle_Charges55,<OPCS>用マンドラゴラが育成可能！,<OPCS> Mandragora available for cultivation!,ui\00_message\ui\ShopTitleCharges_res.gmd,\ui\gui_cmn.arc,gui_cmn.arc,55,

--- a/splits/257.csv
+++ b/splits/257.csv
@@ -190,7 +190,7 @@ Selling price: <VAL GOLD>",ui\00_message\ui\shop.gmd,\ui\uGUIShopBuy.arc,uGUISho
 48,shop_title_clan_quest_sub,クランクエスト,Clan Quest,ui\00_message\ui\shop_title.gmd,\ui\gui_cmn.arc,gui_cmn.arc,48,
 2,shop_title_clan_sub,クラン,Clan Members,ui\00_message\ui\shop_title.gmd,\ui\gui_cmn.arc,gui_cmn.arc,2,
 7,shop_title_craft,Craft,Craft Menu,ui\00_message\ui\shop_title.gmd,\ui\gui_cmn.arc,gui_cmn.arc,7,
-8,shop_title_craft_sub,クラフト, ,ui\00_message\ui\shop_title.gmd,\ui\gui_cmn.arc,gui_cmn.arc,8,
+8,shop_title_craft_sub,クラフト,Craft,ui\00_message\ui\shop_title.gmd,\ui\gui_cmn.arc,gui_cmn.arc,8,
 3,shop_title_cycle_contents,Grand Mission,Grand Mission,ui\00_message\ui\shop_title.gmd,\ui\gui_cmn.arc,gui_cmn.arc,3,
 4,shop_title_cycle_contents_sub,グランドミッション,Grand Mission,ui\00_message\ui\shop_title.gmd,\ui\gui_cmn.arc,gui_cmn.arc,4,
 60,shop_title_daily_mission,リワードミッション,Reward Mission,ui\00_message\ui\shop_title.gmd,\ui\gui_cmn.arc,gui_cmn.arc,60,


### PR DESCRIPTION
Fixing formatting as I encounter them in-game. Only tackling some obvious lines for now while I feel out the new github workflow (so smooth compared to before!)

Also, restoring Craft title to its rightful place. Removed it trying to find overlapping subtitles in the menu, as a test. Left it as a cheeky version control. No one noticed the Craft Menu banner was empty! Will have to find the right entries to remove instead to fix overlapping text.