### PR TITLE
Find and Kill objectives

### DIFF
--- a/Fully Translated/189.csv
+++ b/Fully Translated/189.csv
@@ -214,8 +214,8 @@ on Bloodbane Isle.",ui\00_message\quest_info\q00020150_00.gmd,\ui\history\histor
 3,q00020150_00_2076,ロイグと話す,Speak with Loeg,ui\00_message\quest_info\q00020150_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,3,
 4,q00020150_00_2077,周辺を探索する,Explore the surroundings,ui\00_message\quest_info\q00020150_00.gmd,\quest\q00020150.arc,q00020150.arc,4,Joseph
 4,q00020150_00_2077,周辺を探索する,Explore the surroundings,ui\00_message\quest_info\q00020150_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,4,
-5,q00020150_00_2078,遭遇した魔物を倒す,Defeat the encountered demons,ui\00_message\quest_info\q00020150_00.gmd,\quest\q00020150.arc,q00020150.arc,5,Joseph
-5,q00020150_00_2078,遭遇した魔物を倒す,Defeat the encountered demons,ui\00_message\quest_info\q00020150_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,5,
+5,q00020150_00_2078,遭遇した魔物を倒す,Slay the encountered demons,ui\00_message\quest_info\q00020150_00.gmd,\quest\q00020150.arc,q00020150.arc,5,Joseph
+5,q00020150_00_2078,遭遇した魔物を倒す,Slay the encountered demons,ui\00_message\quest_info\q00020150_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,5,
 6,q00020150_00_2079,新大陸にある礎を探す,Find a portcrystal on the new continent,ui\00_message\quest_info\q00020150_00.gmd,\quest\q00020150.arc,q00020150.arc,6,Joseph
 6,q00020150_00_2079,新大陸にある礎を探す,Find a portcrystal on the new continent,ui\00_message\quest_info\q00020150_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,6,
 7,q00020150_00_2080,礎を解放する,Activate the portcrystal,ui\00_message\quest_info\q00020150_00.gmd,\quest\q00020150.arc,q00020150.arc,7,Klaus

--- a/Fully Translated/191.csv
+++ b/Fully Translated/191.csv
@@ -236,8 +236,8 @@ where the Arisen Corps awaits",ui\00_message\quest_info\q00030410_00.gmd,\ui\his
 within the Great Temple has shown signs of change",ui\00_message\quest_info\q00030410_00.gmd,\quest\q00030410.arc,q00030410.arc,26,Gurdolin
 26,q00030410_00_5050,大神殿内の闇の波動に変化の現れた場所を目指す,"Head to the location where the dark energy
 within the Great Temple has shown signs of change",ui\00_message\quest_info\q00030410_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,26,
-27,q00030410_00_5064,遭遇した魔物を倒す,Defeat the encountered demons,ui\00_message\quest_info\q00030410_00.gmd,\quest\q00030410.arc,q00030410.arc,27,Gurdolin
-27,q00030410_00_5064,遭遇した魔物を倒す,Defeat the encountered demons,ui\00_message\quest_info\q00030410_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,27,
+27,q00030410_00_5064,遭遇した魔物を倒す,Slay the encountered demons,ui\00_message\quest_info\q00030410_00.gmd,\quest\q00030410.arc,q00030410.arc,27,Gurdolin
+27,q00030410_00_5064,遭遇した魔物を倒す,Slay the encountered demons,ui\00_message\quest_info\q00030410_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,27,
 28,q00030410_00_5069,滅びの渦の魔物を倒す,Defeat the demons of the Vortex of Stagnation,ui\00_message\quest_info\q00030410_00.gmd,\quest\q00030410.arc,q00030410.arc,28,Lise
 28,q00030410_00_5069,滅びの渦の魔物を倒す,Defeat the demons of the Vortex of Stagnation,ui\00_message\quest_info\q00030410_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,28,
 29,q00030410_00_5070,始まりの洞へ戻る,Return to the Hollow of Beginnings,ui\00_message\quest_info\q00030410_00.gmd,\quest\q00030410.arc,q00030410.arc,29,Lise
@@ -320,8 +320,8 @@ Megado Corridor in the Royal Capital.",ui\00_message\quest_info\q00030420_00.gmd
 appeared in the Megado Royal Palace layer.",ui\00_message\quest_info\q00030420_00.gmd,\quest\q00030420.arc,q00030420.arc,21,Elliot
 21,q00030420_00_5062,メガド王宮層に出現したゲートの場所へ向かう,"Head towards the location of the gate that 
 appeared in the Megado Royal Palace layer.",ui\00_message\quest_info\q00030420_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,21,
-22,q00030420_00_5063,遭遇した魔物を倒す,Defeat the encountered demons,ui\00_message\quest_info\q00030420_00.gmd,\quest\q00030420.arc,q00030420.arc,22,Elliot
-22,q00030420_00_5063,遭遇した魔物を倒す,Defeat the encountered demons,ui\00_message\quest_info\q00030420_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,22,
+22,q00030420_00_5063,遭遇した魔物を倒す,Slay the encountered demons,ui\00_message\quest_info\q00030420_00.gmd,\quest\q00030420.arc,q00030420.arc,22,Elliot
+22,q00030420_00_5063,遭遇した魔物を倒す,Slay the encountered demons,ui\00_message\quest_info\q00030420_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,22,
 23,q00030420_00_5073,ガルドリンと話す,Speak with Gurdolin,ui\00_message\quest_info\q00030420_00.gmd,\quest\q00030420.arc,q00030420.arc,23,Nedo
 23,q00030420_00_5073,ガルドリンと話す,Speak with Gurdolin,ui\00_message\quest_info\q00030420_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,23,
 24,q00030420_00_5074,滅びの渦へ突入する,Plunge into the Vortex of Stagnation.,ui\00_message\quest_info\q00030420_00.gmd,\quest\q00030420.arc,q00030420.arc,24,Nedo
@@ -402,8 +402,8 @@ the challenge from Travers.",ui\00_message\quest_info\q00030430_00.gmd,\ui\histo
 appeared in Dreed Castle.",ui\00_message\quest_info\q00030430_00.gmd,\quest\q00030430.arc,q00030430.arc,20,Fabio
 20,q00030430_00_5065,ドリード城内に出現したゲートの場所へ向かう,"Head towards the location of the gate that 
 appeared in Dreed Castle.",ui\00_message\quest_info\q00030430_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,20,
-21,q00030430_00_5066,遭遇した魔物を倒す,Defeat the encountered demons,ui\00_message\quest_info\q00030430_00.gmd,\quest\q00030430.arc,q00030430.arc,21,Fabio
-21,q00030430_00_5066,遭遇した魔物を倒す,Defeat the encountered demons,ui\00_message\quest_info\q00030430_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,21,
+21,q00030430_00_5066,遭遇した魔物を倒す,Slay the encountered demons,ui\00_message\quest_info\q00030430_00.gmd,\quest\q00030430.arc,q00030430.arc,21,Fabio
+21,q00030430_00_5066,遭遇した魔物を倒す,Slay the encountered demons,ui\00_message\quest_info\q00030430_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,21,
 22,q00030430_00_5078,ヴァネッサと話す,Speak with Vanessa,ui\00_message\quest_info\q00030430_00.gmd,\quest\q00030430.arc,q00030430.arc,22,Fabio
 22,q00030430_00_5078,ヴァネッサと話す,Speak with Vanessa,ui\00_message\quest_info\q00030430_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,22,
 23,q00030430_00_5079,滅びの渦へ突入する,Plunge into the Vortex of Stagnation.,ui\00_message\quest_info\q00030430_00.gmd,\quest\q00030430.arc,q00030430.arc,23,Fabio
@@ -476,8 +476,8 @@ front of the Mergoda Security District.",ui\00_message\quest_info\q00030440_00.g
 in the Mergoda Security District.",ui\00_message\quest_info\q00030440_00.gmd,\quest\q00030440.arc,q00030440.arc,17,Joseph
 17,q00030440_00_5067,メルゴダ護政区内に出現したゲートの場所ヘ向かう,"Head towards the gate that appeared
 in the Mergoda Security District.",ui\00_message\quest_info\q00030440_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,17,
-18,q00030440_00_5068,遭遇した魔物を倒す,Defeat the encountered demons,ui\00_message\quest_info\q00030440_00.gmd,\quest\q00030440.arc,q00030440.arc,18,Joseph
-18,q00030440_00_5068,遭遇した魔物を倒す,Defeat the encountered demons,ui\00_message\quest_info\q00030440_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,18,
+18,q00030440_00_5068,遭遇した魔物を倒す,Slay the encountered demons,ui\00_message\quest_info\q00030440_00.gmd,\quest\q00030440.arc,q00030440.arc,18,Joseph
+18,q00030440_00_5068,遭遇した魔物を倒す,Slay the encountered demons,ui\00_message\quest_info\q00030440_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,18,
 19,q00030440_00_5083,ミシアルと話す,Speak with Mysial,ui\00_message\quest_info\q00030440_00.gmd,\quest\q00030440.arc,q00030440.arc,19,Joseph
 19,q00030440_00_5083,ミシアルと話す,Speak with Mysial,ui\00_message\quest_info\q00030440_00.gmd,\ui\history\history_data_001.arc,history_data_001.arc,19,
 20,q00030440_00_5084,滅びの渦へ突入する,Plunge into the Vortex of Stagnation.,ui\00_message\quest_info\q00030440_00.gmd,\quest\q00030440.arc,q00030440.arc,20,Joseph

--- a/Fully Translated/197.csv
+++ b/Fully Translated/197.csv
@@ -648,8 +648,7 @@ them without dying.
 Ah―― meeting that person at the 
 barracks is my only pleasure―― 
 Oh, but that's not really a tip!",ui\00_message\quest_info\q21000007_00.gmd,\quest\q21000007.arc,q21000007.arc,3,Clarissa
-4,q21000007_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000007_00.gmd,\quest\q21000007.arc,q21000007.arc,4,Clarissa
+4,q21000007_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000007_00.gmd,\quest\q21000007.arc,q21000007.arc,4,Clarissa
 5,q21000007_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000007_00.gmd,\quest\q21000007.arc,q21000007.arc,5,Clarissa
 6,q21000007_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000007_00.gmd,\quest\q21000007.arc,q21000007.arc,6,Clarissa
 0,q21000008_00_320,洞窟の暴君,The Tyrant of the Cave,ui\00_message\quest_info\q21000008_00.gmd,\quest\q21000008.arc,q21000008.arc,0,Clarissa
@@ -677,8 +676,7 @@ Even when wounded, they have to
 wait for treatment―― 
 But honestly, it's a far bigger issue 
 if I can't see that person!",ui\00_message\quest_info\q21000008_00.gmd,\quest\q21000008.arc,q21000008.arc,3,Clarissa
-4,q21000008_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000008_00.gmd,\quest\q21000008.arc,q21000008.arc,4,Clarissa
+4,q21000008_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000008_00.gmd,\quest\q21000008.arc,q21000008.arc,4,Clarissa
 5,q21000008_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000008_00.gmd,\quest\q21000008.arc,q21000008.arc,5,Clarissa
 6,q21000008_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000008_00.gmd,\quest\q21000008.arc,q21000008.arc,6,Clarissa
 0,q21000009_00_321,漂う妖光,The Wandering Light,ui\00_message\quest_info\q21000009_00.gmd,\quest\q21000009.arc,q21000009.arc,0,
@@ -784,8 +782,7 @@ and disputes among residents.
 I always thought it was the most peaceful village 
 in Lestania, but it seems things are quite 
 difficult now――",ui\00_message\quest_info\q21000012_00.gmd,\quest\q21000012.arc,q21000012.arc,3,Myra
-4,q21000012_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000012_00.gmd,\quest\q21000012.arc,q21000012.arc,4,Myra
+4,q21000012_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000012_00.gmd,\quest\q21000012.arc,q21000012.arc,4,Myra
 5,q21000012_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000012_00.gmd,\quest\q21000012.arc,q21000012.arc,5,Myra
 6,q21000012_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000012_00.gmd,\quest\q21000012.arc,q21000012.arc,6,Myra
 0,q21000013_00_325,忘れられた魔像,The Forgotten Evil Image,ui\00_message\quest_info\q21000013_00.gmd,\quest\q21000013.arc,q21000013.arc,0,
@@ -991,8 +988,7 @@ I spotted monsters I'd never seen
 flying around. Yet the child was 
 so delighted to see them. Boys 
 really do seem to love that sort of thing!",ui\00_message\quest_info\q21000020_00.gmd,\quest\q21000020.arc,q21000020.arc,3,The White Dragon
-4,q21000020_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000020_00.gmd,\quest\q21000020.arc,q21000020.arc,4,Ivan
+4,q21000020_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000020_00.gmd,\quest\q21000020.arc,q21000020.arc,4,Ivan
 5,q21000020_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000020_00.gmd,\quest\q21000020.arc,q21000020.arc,5,Ivan
 6,q21000020_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000020_00.gmd,\quest\q21000020.arc,q21000020.arc,6,Ivan
 0,q21000021_00_333,孤独のハンター,The Lonesome Hunter,ui\00_message\quest_info\q21000021_00.gmd,\quest\q21000021.arc,q21000021.arc,0,Christine
@@ -1035,8 +1031,7 @@ That's commendable, but honestly—
 no matter how hard they work,
 they can't possibly compare to the Arisen; 
 it's just a different starting point.",ui\00_message\quest_info\q21000022_00.gmd,\quest\q21000022.arc,q21000022.arc,3,Sven
-4,q21000022_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000022_00.gmd,\quest\q21000022.arc,q21000022.arc,4,Sven
+4,q21000022_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000022_00.gmd,\quest\q21000022.arc,q21000022.arc,4,Sven
 5,q21000022_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000022_00.gmd,\quest\q21000022.arc,q21000022.arc,5,Sven
 6,q21000022_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000022_00.gmd,\quest\q21000022.arc,q21000022.arc,6,Sven
 0,q21000023_00_335,冷風すさびし路,A Path Hardened by Cold Winds,ui\00_message\quest_info\q21000023_00.gmd,\quest\q21000023.arc,q21000023.arc,0,Rolf

--- a/Fully Translated/198.csv
+++ b/Fully Translated/198.csv
@@ -252,8 +252,7 @@ deeply troubled. They must be a
 person with a strong sense of 
 justice. I hope that people like 
 them find their reward someday.",ui\00_message\quest_info\q21000036_00.gmd,\quest\q21000036.arc,q21000036.arc,3,Sven
-4,q21000036_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000036_00.gmd,\quest\q21000036.arc,q21000036.arc,4,Sven
+4,q21000036_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000036_00.gmd,\quest\q21000036.arc,q21000036.arc,4,Sven
 5,q21000036_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000036_00.gmd,\quest\q21000036.arc,q21000036.arc,5,Sven
 6,q21000036_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000036_00.gmd,\quest\q21000036.arc,q21000036.arc,6,Sven
 0,q21000037_00_349,風光の中で,Within This Beautiful Scenery,ui\00_message\quest_info\q21000037_00.gmd,\quest\q21000037.arc,q21000037.arc,0,
@@ -403,8 +402,7 @@ too cheerful. He mentioned that he's
 not satisfied with the current situation— 
 Since he's usually so straightforward, 
 it seemed all the more serious.",ui\00_message\quest_info\q21000042_00.gmd,\quest\q21000042.arc,q21000042.arc,3,Raul
-4,q21000042_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000042_00.gmd,\quest\q21000042.arc,q21000042.arc,4,Raul
+4,q21000042_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000042_00.gmd,\quest\q21000042.arc,q21000042.arc,4,Raul
 5,q21000042_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000042_00.gmd,\quest\q21000042.arc,q21000042.arc,5,Raul
 6,q21000042_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000042_00.gmd,\quest\q21000042.arc,q21000042.arc,6,Raul
 0,q21000043_00_355,【高難度】鑑賞の邪魔者,【High Difficulty】Thank You for Your Trouble,ui\00_message\quest_info\q21000043_00.gmd,\quest\q21000043.arc,q21000043.arc,0,Roy
@@ -646,8 +644,7 @@ the tavern. He keeps saying he lost to a better
 fighter or something. Isn't it just his own 
 fault for not training hard enough? I wish 
 he'd stop moping at such a lively gathering.",ui\00_message\quest_info\q21000052_00.gmd,\quest\q21000052.arc,q21000052.arc,3,Goltas
-4,q21000052_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000052_00.gmd,\quest\q21000052.arc,q21000052.arc,4,Goltas
+4,q21000052_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000052_00.gmd,\quest\q21000052.arc,q21000052.arc,4,Goltas
 5,q21000052_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000052_00.gmd,\quest\q21000052.arc,q21000052.arc,5,Goltas
 6,q21000052_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000052_00.gmd,\quest\q21000052.arc,q21000052.arc,6,The White Dragon
 0,q21000053_00_372,古跡の厄介者,Menace of the Ruins,ui\00_message\quest_info\q21000053_00.gmd,\quest\q21000053.arc,q21000053.arc,0,
@@ -797,8 +794,7 @@ When I tell others, they just laugh and say
 it's the ramblings of an old man— no one 
 will believe me. I just hope a terrible 
 calamity doesn't strike us soon.",ui\00_message\quest_info\q21000058_00.gmd,\quest\q21000058.arc,q21000058.arc,3,Gort
-4,q21000058_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000058_00.gmd,\quest\q21000058.arc,q21000058.arc,4,Gort
+4,q21000058_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000058_00.gmd,\quest\q21000058.arc,q21000058.arc,4,Gort
 5,q21000058_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000058_00.gmd,\quest\q21000058.arc,q21000058.arc,5,Gort
 6,q21000058_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000058_00.gmd,\quest\q21000058.arc,q21000058.arc,6,Gort
 0,q21000059_00_378,友情はどこまでも,Friends to the End,ui\00_message\quest_info\q21000059_00.gmd,\quest\q21000059.arc,q21000059.arc,0,Rolf
@@ -841,8 +837,7 @@ You need to hone yourself and maintain
 your strength every day— 
 the knights have that resolve. 
 I hope the Arisen also understand this.",ui\00_message\quest_info\q21000060_00.gmd,\quest\q21000060.arc,q21000060.arc,3,Sven
-4,q21000060_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000060_00.gmd,\quest\q21000060.arc,q21000060.arc,4,Sven
+4,q21000060_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000060_00.gmd,\quest\q21000060.arc,q21000060.arc,4,Sven
 5,q21000060_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000060_00.gmd,\quest\q21000060.arc,q21000060.arc,5,Sven
 6,q21000060_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000060_00.gmd,\quest\q21000060.arc,q21000060.arc,6,Sven
 0,q21000061_00_380,洞窟に満ちる悪,The Evil Resounding in the Cave,ui\00_message\quest_info\q21000061_00.gmd,\quest\q21000061.arc,q21000061.arc,0,
@@ -999,8 +994,7 @@ the village, but ended up getting lost myself.
 After wandering for a while, I ran into that 
 monster. Fortunately, it didn't notice me, 
 so I managed to escape with my life.",ui\00_message\quest_info\q21000066_00.gmd,\quest\q21000066.arc,q21000066.arc,3,Ringdeel
-4,q21000066_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000066_00.gmd,\quest\q21000066.arc,q21000066.arc,4,Ringdeel
+4,q21000066_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000066_00.gmd,\quest\q21000066.arc,q21000066.arc,4,Ringdeel
 5,q21000066_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000066_00.gmd,\quest\q21000066.arc,q21000066.arc,5,Ringdeel
 6,q21000066_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000066_00.gmd,\quest\q21000066.arc,q21000066.arc,6,Ringdeel
 0,q21000067_00_386,遺跡の守り人,Guardian of Ancient Remains,ui\00_message\quest_info\q21000067_00.gmd,\quest\q21000067.arc,q21000067.arc,0,Ringdeel
@@ -1065,8 +1059,7 @@ in a battle against an enemy.",ui\00_message\quest_info\q21000069_00.gmd,\quest\
 which seems so savage to a moderate like 
 me! You can survive without brute force. 
 I'd love to teach that loudmouth!",ui\00_message\quest_info\q21000069_00.gmd,\quest\q21000069.arc,q21000069.arc,3,Oliver
-4,q21000069_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000069_00.gmd,\quest\q21000069.arc,q21000069.arc,4,Oliver
+4,q21000069_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000069_00.gmd,\quest\q21000069.arc,q21000069.arc,4,Oliver
 5,q21000069_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000069_00.gmd,\quest\q21000069.arc,q21000069.arc,5,Oliver
 6,q21000069_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000069_00.gmd,\quest\q21000069.arc,q21000069.arc,6,Oliver
 0,q21000070_00_389,この世の地獄,Living Hell,ui\00_message\quest_info\q21000070_00.gmd,\quest\q21000070.arc,q21000070.arc,0,

--- a/Fully Translated/199.csv
+++ b/Fully Translated/199.csv
@@ -20,8 +20,7 @@ to heal the injured.
 So I've made a decision! I won't fight! 
 If I don't fight, I won't get hurt, right? 
 Huh? Is something wrong with that――?",ui\00_message\quest_info\q21000073_00.gmd,\quest\q21000073.arc,q21000073.arc,3,Clarissa
-4,q21000073_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000073_00.gmd,\quest\q21000073.arc,q21000073.arc,4,Clarissa
+4,q21000073_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000073_00.gmd,\quest\q21000073.arc,q21000073.arc,4,Clarissa
 5,q21000073_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000073_00.gmd,\quest\q21000073.arc,q21000073.arc,5,Clarissa
 6,q21000073_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000073_00.gmd,\quest\q21000073.arc,q21000073.arc,6,Clarissa
 0,q21000074_00_393,【高難度】若き力のために,【High Difficulty】For Youthful Strength,ui\00_message\quest_info\q21000074_00.gmd,\quest\q21000074.arc,q21000074.arc,0,Bertrand
@@ -260,8 +259,7 @@ is a daily routine.
 In fact, it's the thrill that keeps me coming back. 
 That's right, it's the foolish ones who flock here. 
 ―It's simply irresistible.",ui\00_message\quest_info\q21000083_00.gmd,\quest\q21000083.arc,q21000083.arc,3,Dian
-4,q21000083_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000083_00.gmd,\quest\q21000083.arc,q21000083.arc,4,The White Dragon
+4,q21000083_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000083_00.gmd,\quest\q21000083.arc,q21000083.arc,4,The White Dragon
 5,q21000083_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000083_00.gmd,\quest\q21000083.arc,q21000083.arc,5,The White Dragon
 6,q21000083_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000083_00.gmd,\quest\q21000083.arc,q21000083.arc,6,The White Dragon
 0,q21000084_00_364,放浪の果てに,At the End of One's Wandering,ui\00_message\quest_info\q21000084_00.gmd,\quest\q21000084.arc,q21000084.arc,0,Dian
@@ -380,8 +378,7 @@ in a battle against an enemy.",ui\00_message\quest_info\q21000088_00.gmd,\quest\
 The people here each have their own determination. 
 But seeing the monsters running wild, 
 the peaceful times feel like a memory from long ago.",ui\00_message\quest_info\q21000088_00.gmd,\quest\q21000088.arc,q21000088.arc,3,Theodor
-4,q21000088_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000088_00.gmd,\quest\q21000088.arc,q21000088.arc,4,The White Dragon
+4,q21000088_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000088_00.gmd,\quest\q21000088.arc,q21000088.arc,4,The White Dragon
 5,q21000088_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000088_00.gmd,\quest\q21000088.arc,q21000088.arc,5,The White Dragon
 6,q21000088_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000088_00.gmd,\quest\q21000088.arc,q21000088.arc,6,The White Dragon
 0,q21000089_00_408,亡者の誘い声,Call from the Undead ,ui\00_message\quest_info\q21000089_00.gmd,\quest\q21000089.arc,q21000089.arc,0,Ariadne
@@ -564,8 +561,7 @@ I've never encountered such a horrifying monster.
 I'm such a cold-hearted person, aren't I? 
 So heartless—so heartless— 
 damn it, ever since that day, it's consumed my thoughts!",ui\00_message\quest_info\q21000096_00.gmd,\quest\q21000096.arc,q21000096.arc,3,Clarissa
-4,q21000096_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21000096_00.gmd,\quest\q21000096.arc,q21000096.arc,4,Clarissa
+4,q21000096_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21000096_00.gmd,\quest\q21000096.arc,q21000096.arc,4,Clarissa
 5,q21000096_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21000096_00.gmd,\quest\q21000096.arc,q21000096.arc,5,Clarissa
 6,q21000096_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21000096_00.gmd,\quest\q21000096.arc,q21000096.arc,6,Clarissa
 0,q21000097_00_416,秘密の取引き,Secret Dealings,ui\00_message\quest_info\q21000097_00.gmd,\quest\q21000097.arc,q21000097.arc,0,Gunther
@@ -687,8 +683,7 @@ on the Phindym continent that no one has witnessed.
 To check it out, I infiltrated an expedition team. 
 And sure enough, there were many things I'd never seen, 
 along with many monsters I had never faced before.",ui\00_message\quest_info\q21014001_00.gmd,\quest\q21014001.arc,q21014001.arc,3,Fabio
-4,q21014001_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21014001_00.gmd,\quest\q21014001.arc,q21014001.arc,4,Fabio
+4,q21014001_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21014001_00.gmd,\quest\q21014001.arc,q21014001.arc,4,Fabio
 5,q21014001_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21014001_00.gmd,\quest\q21014001.arc,q21014001.arc,5,Fabio
 6,q21014001_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21014001_00.gmd,\quest\q21014001.arc,q21014001.arc,6,Fabio
 0,q21014002_00_542,【高難度】密林の潜伏者,【High Difficulty】Lurker in the Deep Woods,ui\00_message\quest_info\q21014002_00.gmd,\quest\q21014002.arc,q21014002.arc,0,Mucel
@@ -1020,8 +1015,7 @@ You're coordinating many subordinates,
 handling invisible relationships and 
 jealousies—it's quite a hassle, isn't it? 
 Someone should really be there to lend support.",ui\00_message\quest_info\q21014015_00.gmd,\quest\q21014015.arc,q21014015.arc,3,Dirith
-4,q21014015_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21014015_00.gmd,\quest\q21014015.arc,q21014015.arc,4,Dirith
+4,q21014015_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21014015_00.gmd,\quest\q21014015.arc,q21014015.arc,4,Dirith
 5,q21014015_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21014015_00.gmd,\quest\q21014015.arc,q21014015.arc,5,Dirith
 6,q21014015_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21014015_00.gmd,\quest\q21014015.arc,q21014015.arc,6,Dirith
 0,q21014016_00_603,類猿の血族,Simian Relatives,ui\00_message\quest_info\q21014016_00.gmd,\quest\q21014016.arc,q21014016.arc,0,The White Dragon

--- a/Fully Translated/200.csv
+++ b/Fully Translated/200.csv
@@ -93,8 +93,7 @@ and I regretted it. There's
 a harrowing history concealed 
 behind the lush nature 
 and warm-hearted people.",ui\00_message\quest_info\q21014021_00.gmd,\quest\q21014021.arc,q21014021.arc,3,Eluned
-4,q21014021_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21014021_00.gmd,\quest\q21014021.arc,q21014021.arc,4,Eluned
+4,q21014021_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21014021_00.gmd,\quest\q21014021.arc,q21014021.arc,4,Eluned
 5,q21014021_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21014021_00.gmd,\quest\q21014021.arc,q21014021.arc,5,Eluned
 6,q21014021_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21014021_00.gmd,\quest\q21014021.arc,q21014021.arc,6,Eluned
 0,q21014022_00_609,【高難度】駆けゆく野生,【High Difficulty】Rushing Wild,ui\00_message\quest_info\q21014022_00.gmd,\quest\q21014022.arc,q21014022.arc,0,Mucel
@@ -229,8 +228,7 @@ The village warriors are fired up,
 thinking a stranger could take down Dana's nemesis. 
 I just hope no one loses their life.",ui\00_message\quest_info\q21015001_00.gmd,\quest\q21015001.arc,q21015001.arc,3,Fionn
 5,q21015001_00_1171,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21015001_00.gmd,\quest\q21015001.arc,q21015001.arc,5,Fionn
-4,q21015001_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21015001_00.gmd,\quest\q21015001.arc,q21015001.arc,4,Fionn
+4,q21015001_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21015001_00.gmd,\quest\q21015001.arc,q21015001.arc,4,Fionn
 6,q21015001_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21015001_00.gmd,\quest\q21015001.arc,q21015001.arc,6,Fionn
 0,q21015002_00_590,【高難度】魔影の侵攻,【High Difficulty】The Specter's Invasion,ui\00_message\quest_info\q21015002_00.gmd,\quest\q21015002.arc,q21015002.arc,0,Razanailt
 1,q21015002_00_590,"【連続討伐クエスト】
@@ -424,8 +422,7 @@ during my stay, it was the weak
 who were caring and kind to me. 
 I wish I could find a way to 
 repay their kindness.",ui\00_message\quest_info\q21015009_00.gmd,\quest\q21015009.arc,q21015009.arc,3,Flannan
-4,q21015009_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21015009_00.gmd,\quest\q21015009.arc,q21015009.arc,4,Flannan
+4,q21015009_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21015009_00.gmd,\quest\q21015009.arc,q21015009.arc,4,Flannan
 5,q21015009_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21015009_00.gmd,\quest\q21015009.arc,q21015009.arc,5,Flannan
 6,q21015009_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21015009_00.gmd,\quest\q21015009.arc,q21015009.arc,6,Flannan
 0,q21015010_00_598,昔取った槍柄,An Old Hand at the Spear ,ui\00_message\quest_info\q21015010_00.gmd,\quest\q21015010.arc,q21015010.arc,0,Odran
@@ -583,8 +580,7 @@ the threat posed by monsters.
 Monsters are not worthy foes. 
 Perhaps one day, they will 
 realize this firsthand.",ui\00_message\quest_info\q21015015_00.gmd,\quest\q21015015.arc,q21015015.arc,3,Evey
-4,q21015015_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21015015_00.gmd,\quest\q21015015.arc,q21015015.arc,4,Evey
+4,q21015015_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21015015_00.gmd,\quest\q21015015.arc,q21015015.arc,4,Evey
 5,q21015015_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21015015_00.gmd,\quest\q21015015.arc,q21015015.arc,5,Evey
 6,q21015015_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21015015_00.gmd,\quest\q21015015.arc,q21015015.arc,6,Evey
 0,q21015016_00_631,水路を焦がす稲妻,Lightning Scorching the Waterway ,ui\00_message\quest_info\q21015016_00.gmd,\quest\q21015016.arc,q21015016.arc,0,The White Dragon
@@ -749,8 +745,7 @@ mischievous creatures. Still,
 they're just lesser demons— 
 boasting about their grand towers, 
 how audacious!",ui\00_message\quest_info\q21015021_00.gmd,\quest\q21015021.arc,q21015021.arc,3,Dewi
-4,q21015021_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21015021_00.gmd,\quest\q21015021.arc,q21015021.arc,4,Dewi
+4,q21015021_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21015021_00.gmd,\quest\q21015021.arc,q21015021.arc,4,Dewi
 5,q21015021_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21015021_00.gmd,\quest\q21015021.arc,q21015021.arc,5,Dewi
 6,q21015021_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21015021_00.gmd,\quest\q21015021.arc,q21015021.arc,6,Dewi
 0,q21015022_00_637,【高難度】猛き王者の咆哮,【High Difficulty】The Fierce King's Roar,ui\00_message\quest_info\q21015022_00.gmd,\quest\q21015022.arc,q21015022.arc,0,Razanailt
@@ -884,8 +879,7 @@ gossiping and arguing, leading to
 a really dreary vibe. I wish 
 someone would come and brighten 
 the mood.",ui\00_message\quest_info\q21016001_00.gmd,\quest\q21016001.arc,q21016001.arc,3,Finbar
-4,q21016001_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21016001_00.gmd,\quest\q21016001.arc,q21016001.arc,4,Finbar
+4,q21016001_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21016001_00.gmd,\quest\q21016001.arc,q21016001.arc,4,Finbar
 5,q21016001_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21016001_00.gmd,\quest\q21016001.arc,q21016001.arc,5,Finbar
 6,q21016001_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21016001_00.gmd,\quest\q21016001.arc,q21016001.arc,6,Finbar
 0,q21016002_00_574,【高難度】終止符を打つために,【High Difficulty】To End This,ui\00_message\quest_info\q21016002_00.gmd,\quest\q21016002.arc,q21016002.arc,0,Arthfael

--- a/Fully Translated/201.csv
+++ b/Fully Translated/201.csv
@@ -81,8 +81,7 @@ on the verge of being
 tainted. With so many 
 showing up, I'm worried 
 it might soon become lost.",ui\00_message\quest_info\q21016015_00.gmd,\quest\q21016015.arc,q21016015.arc,3,Milan
-4,q21016015_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21016015_00.gmd,\quest\q21016015.arc,q21016015.arc,4,Milan
+4,q21016015_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21016015_00.gmd,\quest\q21016015.arc,q21016015.arc,4,Milan
 5,q21016015_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21016015_00.gmd,\quest\q21016015.arc,q21016015.arc,5,Milan
 6,q21016015_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21016015_00.gmd,\quest\q21016015.arc,q21016015.arc,6,Milan
 0,q21016016_00_622,侵鬼の手招き,Beckoning Demons ,ui\00_message\quest_info\q21016016_00.gmd,\quest\q21016016.arc,q21016016.arc,0,The White Dragon
@@ -239,8 +238,7 @@ in one place. While the
 exact reason is unknown, 
 it's thought to relate to 
 their breeding season.",ui\00_message\quest_info\q21016021_00.gmd,\quest\q21016021.arc,q21016021.arc,3,Thorin
-4,q21016021_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21016021_00.gmd,\quest\q21016021.arc,q21016021.arc,4,Thorin
+4,q21016021_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21016021_00.gmd,\quest\q21016021.arc,q21016021.arc,4,Thorin
 5,q21016021_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21016021_00.gmd,\quest\q21016021.arc,q21016021.arc,5,Thorin
 6,q21016021_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21016021_00.gmd,\quest\q21016021.arc,q21016021.arc,6,Thorin
 0,q21016022_00_628,【高難度】再来の緑魔,【High Difficulty】The Green Demon's Return,ui\00_message\quest_info\q21016022_00.gmd,\quest\q21016022.arc,q21016022.arc,0,Arthfael
@@ -372,8 +370,7 @@ so terrifyingly powerful monsters sometimes show up.
 In those times, warriors from other villages 
 come together to repel them, 
 but lately, it doesn't seem like that will work well.",ui\00_message\quest_info\q21017001_00.gmd,\quest\q21017001.arc,q21017001.arc,3,Mavail
-4,q21017001_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21017001_00.gmd,\quest\q21017001.arc,q21017001.arc,4,Mavail
+4,q21017001_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21017001_00.gmd,\quest\q21017001.arc,q21017001.arc,4,Mavail
 5,q21017001_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21017001_00.gmd,\quest\q21017001.arc,q21017001.arc,5,Mavail
 6,q21017001_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21017001_00.gmd,\quest\q21017001.arc,q21017001.arc,6,Mavail
 0,q21017002_00_558,【高難度】深淵の伏魔殿,【High Difficulty】The Mayhem Abyss,ui\00_message\quest_info\q21017002_00.gmd,\quest\q21017002.arc,q21017002.arc,0,Ciarán
@@ -663,8 +660,7 @@ There are times when you're challenged
 to a fight to test your skills. 
 If you show your prowess, 
 you'll surely earn their respect.",ui\00_message\quest_info\q21017012_00.gmd,\quest\q21017012.arc,q21017012.arc,3,Maeve
-4,q21017012_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21017012_00.gmd,\quest\q21017012.arc,q21017012.arc,4,Maeve
+4,q21017012_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21017012_00.gmd,\quest\q21017012.arc,q21017012.arc,4,Maeve
 5,q21017012_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21017012_00.gmd,\quest\q21017012.arc,q21017012.arc,5,Maeve
 6,q21017012_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21017012_00.gmd,\quest\q21017012.arc,q21017012.arc,6,Maeve
 0,q21017013_00_569,消えた足音に気付く時,When the Footsteps Fade,ui\00_message\quest_info\q21017013_00.gmd,\quest\q21017013.arc,q21017013.arc,0,Sullivan
@@ -731,8 +727,7 @@ rumors spread quickly.
 Plus, with the ruins as prime gossip material, 
 all sorts of tales can circulate easily. 
 Most of it is just nonsense, though.",ui\00_message\quest_info\q21017015_00.gmd,\quest\q21017015.arc,q21017015.arc,3,Oengus
-4,q21017015_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21017015_00.gmd,\quest\q21017015.arc,q21017015.arc,4,Oengus
+4,q21017015_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21017015_00.gmd,\quest\q21017015.arc,q21017015.arc,4,Oengus
 5,q21017015_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21017015_00.gmd,\quest\q21017015.arc,q21017015.arc,5,Oengus
 6,q21017015_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21017015_00.gmd,\quest\q21017015.arc,q21017015.arc,6,Oengus
 0,q21017016_00_612,スクラップ・メイカー,Scrap Maker,ui\00_message\quest_info\q21017016_00.gmd,\quest\q21017016.arc,q21017016.arc,0,The White Dragon
@@ -890,8 +885,7 @@ There doesn't seem to be anything special
 about the tower itself. Buildings are meant 
 to protect those inside, so I'm curious 
 why it's interpreted that way.",ui\00_message\quest_info\q21017021_00.gmd,\quest\q21017021.arc,q21017021.arc,3,Berenas
-4,q21017021_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q21017021_00.gmd,\quest\q21017021.arc,q21017021.arc,4,Berenas
+4,q21017021_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q21017021_00.gmd,\quest\q21017021.arc,q21017021.arc,4,Berenas
 5,q21017021_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q21017021_00.gmd,\quest\q21017021.arc,q21017021.arc,5,Berenas
 6,q21017021_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q21017021_00.gmd,\quest\q21017021.arc,q21017021.arc,6,Berenas
 0,q21017022_00_618,【高難度】邂逅の厄災,【High Difficulty】A Disastrous Encounter,ui\00_message\quest_info\q21017022_00.gmd,\quest\q21017022.arc,q21017022.arc,0,Ciarán
@@ -1021,8 +1015,7 @@ it is not only humans and orcs
 who are struggling to survive. 
 We must also overcome the monsters
 that dwell in the wilderness.",ui\00_message\quest_info\q22018001_00.gmd,\quest\q22018001.arc,q22018001.arc,3,Bruno
-4,q22018001_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q22018001_00.gmd,\quest\q22018001.arc,q22018001.arc,4,Bruno
+4,q22018001_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q22018001_00.gmd,\quest\q22018001.arc,q22018001.arc,4,Bruno
 5,q22018001_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q22018001_00.gmd,\quest\q22018001.arc,q22018001.arc,5,Bruno
 6,q22018001_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q22018001_00.gmd,\quest\q22018001.arc,q22018001.arc,6,Bruno
 0,q22018002_00_642,命知らずの敢行,A Reckless Action,ui\00_message\quest_info\q22018002_00.gmd,\quest\q22018002.arc,q22018002.arc,0,Andrea

--- a/Fully Translated/202.csv
+++ b/Fully Translated/202.csv
@@ -142,8 +142,7 @@ in a battle against an enemy.",ui\00_message\quest_info\q22018011_00.gmd,\quest\
 targeting disaster-struck ruins like vultures.
 I can't speak too harshly, given our need for help,
 but it's really disheartening.",ui\00_message\quest_info\q22018011_00.gmd,\quest\q22018011.arc,q22018011.arc,3,Gerald
-4,q22018011_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q22018011_00.gmd,\quest\q22018011.arc,q22018011.arc,4,Gerald
+4,q22018011_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q22018011_00.gmd,\quest\q22018011.arc,q22018011.arc,4,Gerald
 5,q22018011_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q22018011_00.gmd,\quest\q22018011.arc,q22018011.arc,5,Gerald
 6,q22018011_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q22018011_00.gmd,\quest\q22018011.arc,q22018011.arc,6,Gerald
 0,q22018012_00_652,【時限採取】鬼の居ぬ間の採石道,Time Restriction: Mining Free of Demons,ui\00_message\quest_info\q22018012_00.gmd,\quest\q22018012.arc,q22018012.arc,0,Endale
@@ -215,8 +214,7 @@ didn't she? She was always shy
 and a bit of an oddball.
 But sometimes, those kinds of kids
 end up achieving great things.",ui\00_message\quest_info\q22018014_00.gmd,\quest\q22018014.arc,q22018014.arc,3,Michaela
-4,q22018014_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q22018014_00.gmd,\quest\q22018014.arc,q22018014.arc,4,Michaela
+4,q22018014_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q22018014_00.gmd,\quest\q22018014.arc,q22018014.arc,4,Michaela
 5,q22018014_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q22018014_00.gmd,\quest\q22018014.arc,q22018014.arc,5,Michaela
 6,q22018014_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q22018014_00.gmd,\quest\q22018014.arc,q22018014.arc,6,Michaela
 0,q22018015_00_655,女番頭の憂い事,The Clerk's Misery,ui\00_message\quest_info\q22018015_00.gmd,\quest\q22018015.arc,q22018015.arc,0,Selma
@@ -319,8 +317,7 @@ in a battle against an enemy.",ui\00_message\quest_info\q22018018_00.gmd,\quest\
 They looked really cool!
 I wish the Liberation Army
 would recruit monsters too!",ui\00_message\quest_info\q22018018_00.gmd,\quest\q22018018.arc,q22018018.arc,3,Artin
-4,q22018018_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q22018018_00.gmd,\quest\q22018018.arc,q22018018.arc,4,Artin
+4,q22018018_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q22018018_00.gmd,\quest\q22018018.arc,q22018018.arc,4,Artin
 5,q22018018_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q22018018_00.gmd,\quest\q22018018.arc,q22018018.arc,5,Artin
 6,q22018018_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q22018018_00.gmd,\quest\q22018018.arc,q22018018.arc,6,Artin
 0,q22018019_00_659,睦まじき日をもう一度,Happy Days Once Again,ui\00_message\quest_info\q22018019_00.gmd,\quest\q22018019.arc,q22018019.arc,0,Khalil
@@ -587,8 +584,7 @@ Many who have lost their parents
 or have been prisoners carry deep emotional scars.
 Only time can heal them, but I wish there was 
 something more we could do to help.",ui\00_message\quest_info\q22018029_00.gmd,\quest\q22018029.arc,q22018029.arc,3,Adem
-4,q22018029_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q22018029_00.gmd,\quest\q22018029.arc,q22018029.arc,4,Adem
+4,q22018029_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q22018029_00.gmd,\quest\q22018029.arc,q22018029.arc,4,Adem
 5,q22018029_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q22018029_00.gmd,\quest\q22018029.arc,q22018029.arc,5,Adem
 6,q22018029_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q22018029_00.gmd,\quest\q22018029.arc,q22018029.arc,6,Adem
 0,q22018030_00_670,積怨の禍つ鎧,Malicious Armor,ui\00_message\quest_info\q22018030_00.gmd,\quest\q22018030.arc,q22018030.arc,0,Birger
@@ -672,8 +668,7 @@ I thought it might be the Orcs causing the noise,
 but it sounds more like a big creature walking――
 I wonder if I should consult someone well-versed
 in the history of Acre Selund.",ui\00_message\quest_info\q22018032_00.gmd,\quest\q22018032.arc,q22018032.arc,3,Mustafa
-4,q22018032_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q22018032_00.gmd,\quest\q22018032.arc,q22018032.arc,4,Mustafa
+4,q22018032_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q22018032_00.gmd,\quest\q22018032.arc,q22018032.arc,4,Mustafa
 5,q22018032_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q22018032_00.gmd,\quest\q22018032.arc,q22018032.arc,5,Mustafa
 6,q22018032_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q22018032_00.gmd,\quest\q22018032.arc,q22018032.arc,6,Mustafa
 0,q22018033_00_685,いにしえの邪眼,Ancient Evil Eye,ui\00_message\quest_info\q22018033_00.gmd,\quest\q22018033.arc,q22018033.arc,0,
@@ -745,8 +740,7 @@ you'll end up overwhelmed by their numbers
 and be forced to flee... As someone who has
 experienced this, I can tell you this is true.",ui\00_message\quest_info\q22018035_00.gmd,\quest\q22018035.arc,q22018035.arc,3,Lucas
 5,q22018035_00_1162,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q22018035_00.gmd,\quest\q22018035.arc,q22018035.arc,5,Lucas
-4,q22018035_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q22018035_00.gmd,\quest\q22018035.arc,q22018035.arc,4,Lucas
+4,q22018035_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q22018035_00.gmd,\quest\q22018035.arc,q22018035.arc,4,Lucas
 6,q22018035_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q22018035_00.gmd,\quest\q22018035.arc,q22018035.arc,6,Lucas
 0,q22018036_00_688,やるかたなき宿怨,A Bitter Old Grudge,ui\00_message\quest_info\q22018036_00.gmd,\quest\q22018036.arc,q22018036.arc,0,Umit
 1,q22018036_00_688,"【納品討伐クエスト】
@@ -791,8 +785,7 @@ during training makes us flee in fear.
 The future of Acre Selund depends on us,
 and it's truly pathetic.",ui\00_message\quest_info\q22018037_00.gmd,\quest\q22018037.arc,q22018037.arc,3,Lucas
 5,q22018037_00_1162,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q22018037_00.gmd,\quest\q22018037.arc,q22018037.arc,5,Lucas
-4,q22018037_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q22018037_00.gmd,\quest\q22018037.arc,q22018037.arc,4,Lucas
+4,q22018037_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q22018037_00.gmd,\quest\q22018037.arc,q22018037.arc,4,Lucas
 6,q22018037_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q22018037_00.gmd,\quest\q22018037.arc,q22018037.arc,6,Lucas
 0,q22018038_00_690,闇より溢れ出る異変,Something Spilling from the Darkness,ui\00_message\quest_info\q22018038_00.gmd,\quest\q22018038.arc,q22018038.arc,0,Kirsty
 1,q22018038_00_690,"【敵群討伐クエスト】
@@ -970,8 +963,7 @@ If that child asks me for anything, I'll do it,
 whether it's carrying goods or monster hunting!
 I can't refuse when looked at with those eyes!",ui\00_message\quest_info\q22018044_00.gmd,\quest\q22018044.arc,q22018044.arc,3,Muge
 5,q22018044_00_1162,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q22018044_00.gmd,\quest\q22018044.arc,q22018044.arc,5,Muge
-4,q22018044_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q22018044_00.gmd,\quest\q22018044.arc,q22018044.arc,4,Muge
+4,q22018044_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q22018044_00.gmd,\quest\q22018044.arc,q22018044.arc,4,Muge
 6,q22018044_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q22018044_00.gmd,\quest\q22018044.arc,q22018044.arc,6,Muge
 0,q22018045_00_697,門番の矜持,The Gatekeeper's Pride,ui\00_message\quest_info\q22018045_00.gmd,\quest\q22018045.arc,q22018045.arc,0,Demir
 1,q22018045_00_697,"【納品討伐クエスト】

--- a/Fully Translated/203.csv
+++ b/Fully Translated/203.csv
@@ -111,8 +111,7 @@ building in the Northern Urteca Mountains,
 and that ""those who encounter it never return.""
 In the current situation, no one dares to go near,
 but if it's true, it's a serious matter.",ui\00_message\quest_info\q22018053_00.gmd,\quest\q22018053.arc,q22018053.arc,3,Cory
-4,q22018053_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q22018053_00.gmd,\quest\q22018053.arc,q22018053.arc,4,Cory
+4,q22018053_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q22018053_00.gmd,\quest\q22018053.arc,q22018053.arc,4,Cory
 5,q22018053_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q22018053_00.gmd,\quest\q22018053.arc,q22018053.arc,5,Cory
 6,q22018053_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q22018053_00.gmd,\quest\q22018053.arc,q22018053.arc,6,Cory
 0,q22018054_00_707,拭えぬ心労,Unshakeable Anxiety,ui\00_message\quest_info\q22018054_00.gmd,\quest\q22018054.arc,q22018054.arc,0,Sema
@@ -217,8 +216,7 @@ It appears they're summoning more
 from the surrounding regions.
 We need to hit them hard to send a message.",ui\00_message\quest_info\q22018057_00.gmd,\quest\q22018057.arc,q22018057.arc,3,Zef
 5,q22018057_00_1162,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q22018057_00.gmd,\quest\q22018057.arc,q22018057.arc,5,Zef
-4,q22018057_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q22018057_00.gmd,\quest\q22018057.arc,q22018057.arc,4,Zef
+4,q22018057_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q22018057_00.gmd,\quest\q22018057.arc,q22018057.arc,4,Zef
 6,q22018057_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q22018057_00.gmd,\quest\q22018057.arc,q22018057.arc,6,Zef
 0,q22018058_00_711,【高難度】アッカーシェラン各地より救援要請,High Difficulty: Rescue Acre Selund,ui\00_message\quest_info\q22018058_00.gmd,\quest\q22018058.arc,q22018058.arc,0,Bacias
 1,q22018058_00_711,"【連続討伐クエスト】
@@ -512,8 +510,7 @@ in a battle against an enemy.",ui\00_message\quest_info\q29999990_00.gmd,\quest\
 １２３４５６７８９０１２３４５６７８９０１２３４５６７
 １２３４５６７８９０１２３４５６７８９０１２３４５６７
 １２３４５６７８９０１２３４５６７８９０１２３４５６７",ui\00_message\quest_info\q29999990_00.gmd,\quest\q29999990.arc,q29999990.arc,3,Mayleaf
-4,q29999990_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Go to the designated location
-and find the rabid demon",ui\00_message\quest_info\q29999990_00.gmd,\quest\q29999990.arc,q29999990.arc,4,Mayleaf
+4,q29999990_00_1174,指定された場所へ行き、狂暴な魔物を見つける,"Root out the rabid beasts",ui\00_message\quest_info\q29999990_00.gmd,\quest\q29999990.arc,q29999990.arc,4,Mayleaf
 5,q29999990_00_1175,遭遇した魔物を討伐する,Defeat the encountered demons,ui\00_message\quest_info\q29999990_00.gmd,\quest\q29999990.arc,q29999990.arc,5,0
 6,q29999990_00_1176,依頼者へ経緯を報告する,Report back to the requester,ui\00_message\quest_info\q29999990_00.gmd,\quest\q29999990.arc,q29999990.arc,6,
 7,q29999990_00_1178,依頼者からの報酬を得る,Collect the reward from the requester,ui\00_message\quest_info\q29999990_00.gmd,\quest\q29999990.arc,q29999990.arc,7,

--- a/splits/211.csv
+++ b/splits/211.csv
@@ -114,7 +114,7 @@ land and recover villagers' property",ui\00_message\quest_info\q60200200_00.gmd,
 2,q60200201_00_2696,メイリーフと会い話を聞く,Meet with Mayleaf and hear her story.,ui\00_message\quest_info\q60200201_00.gmd,\quest\q60200201.arc,q60200201.arc,2,Joseph
 3,q60200201_00_2697,南方のディナン深層林＜<SPOT 561>＞へ向かう,"Head to ""<SPOT 561>"" of southern Deenan Woods",ui\00_message\quest_info\q60200201_00.gmd,\quest\q60200201.arc,q60200201.arc,3,Joseph
 4,q60200201_00_2698,<SPOT 561>内を調査する,Investigate inside <SPOT 561>,ui\00_message\quest_info\q60200201_00.gmd,\quest\q60200201.arc,q60200201.arc,4,Klaus
-5,q60200201_00_2699,遭遇した魔物を倒す,Defeat the encountered demons,ui\00_message\quest_info\q60200201_00.gmd,\quest\q60200201.arc,q60200201.arc,5,Klaus
+5,q60200201_00_2699,遭遇した魔物を倒す,Slay the encountered demons,ui\00_message\quest_info\q60200201_00.gmd,\quest\q60200201.arc,q60200201.arc,5,Klaus
 6,q60200201_00_2700,＜<SPOT 556>＞でリズと合流する,"Rendezvous with Lise at ""<SPOT 556>""",ui\00_message\quest_info\q60200201_00.gmd,\quest\q60200201.arc,q60200201.arc,6,Klaus
 7,q60200201_00_2701,ロンドジールと話す,Speak with Rondejeel,ui\00_message\quest_info\q60200201_00.gmd,\quest\q60200201.arc,q60200201.arc,7,Pamela
 8,q60200201_00_2702,＜<SPOT 475>＞へ向かう,"Head to ""<SPOT 475>""",ui\00_message\quest_info\q60200201_00.gmd,\quest\q60200201.arc,q60200201.arc,8,Pamela


### PR DESCRIPTION
Go to the designated location and find the rabid demon > Root out the rabid beasts

Compressed the meaning of "go there" + "get rid of someone/something" (implied) with "Root out"

Changed demon > beasts as "mamono" [魔物] is a vague term meaning any sort of evil or dangerous creature, informed by the fact that these quests have you fight Wolves and Saurians in the pool of possible enemies. Did not change to "enemies" as that would be "teki" [敵] which is not used here.

Possible to add a (s) on beast(s) if ever there is just one enemy encountered.

~

We have two versions of "Defeat the encountered demons" that are translated the same.

106 instances of [遭遇した魔物を**討伐する**]
11 instances of [遭遇した魔物を**倒す**] _<< the subject of this commit_

In fact there is a slight difference, the one using [討伐する] "tōbatsusuru" which means to subjugate or subdue in a military context, e.g. to vanquish a foe, and this one I am changing with [倒す] "taosu" is more of a simple kill order.

This doesn't have to be the final version, I'm changing it now so that it's easily differentiated for an English reader.
Personally, I would prefer if the former phrase [遭遇した魔物を討伐する] is translated to "Vanquish the encountered enemy" and then this latter one [遭遇した魔物を倒す] becomes Defeat the encountered enemy. This would be purposely overlooking  [魔物] "mamono" and changing it to "the target" as the player sees in game. This solution seems the most intuitive to me as these objective strings are part two of quests given by NPCs:

1. go find them (what+where?)
2. defeat them (here!)

World Quests will start on the defeat-upon-encounter objective.

In addition, the use of [魔物] "mamono" in both these phrases also refers to non-demons, so that will have to be changed later.