### PR TITLE
"Fiend" recontext 魔物 > 魔族

### DIFF
--- a/English/Fully Translated/097.csv
+++ b/English/Fully Translated/097.csv
@@ -233,8 +233,7 @@ its strength...",ui\00_message\npc\base\n0001.gmd,\npc\n0001.arc,n0001.arc,5,The
 Far yonder, beyond where thine eyes reach...",ui\00_message\npc\base\n0001.gmd,\npc\n0001.arc,n0001.arc,7,The White Dragon
 0,,"漂う穢れた気は――
 魔物どもが発するもののようだ","Drifting defilement...  
-The noisome breath
-of the fell spawn of fiends...",ui\00_message\npc\base\n0001.gmd,\npc\n0001.arc,n0001.arc,30,The White Dragon
+The noisome breath of fell spawn...",ui\00_message\npc\base\n0001.gmd,\npc\n0001.arc,n0001.arc,30,The White Dragon
 0,,"王子の持つ笛とはいかなる理が
 はたらくものなのだろうか――","What principle doth govern  
 the flute the Prince doth hold...",ui\00_message\npc\base\n0001.gmd,\npc\n0001.arc,n0001.arc,96,The White Dragon

--- a/English/Fully Translated/108.csv
+++ b/English/Fully Translated/108.csv
@@ -333,8 +333,8 @@ When passing by nearby, be sure not to neglect
 your vigilance and remain on high alert.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,19,Ciarán
 0,,"《<SPOT 945>》についてはもちろん問題だが
 最近はこのキンガル全域で
-魔族が活性化してきている節もある――","Regarding 《<SPOT 945>》, of course, there are
-issues.
-However, recently, there seems to be an
-invigoration of Fiends throughout the entire
-region of Kingal.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,20,Ciarán
+魔族が活性化してきている節もある――","Regarding 《<SPOT 945>》,
+of course, there are issues.
+However, there seems to be an invigoration
+of Fiends throughout the entire region
+of Kingal, as of late.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,20,Ciarán

--- a/English/Fully Translated/111.csv
+++ b/English/Fully Translated/111.csv
@@ -113,11 +113,11 @@ of this village, Ser.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc
 0,,"先日、シェドレアン大神殿前の橋の
 修繕が終わったのは知っているか？
 実は、そこへ魔族が現れ
-いまだ通行が難しくなっている","Did you know that the repairs on the bridge in
-front of the Shadolean Great Temple were completed
-the other day?
-Actually, fiends have appeared there, making it
-still difficult to pass through.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,43,Ciarán
+いまだ通行が難しくなっている","Did you know that the bridge
+leading into the Shadolean Great Temple
+was finally repaired the other day?
+Some terrible abominations have appeared there,
+making it still difficult to pass through.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,43,Ciarán
 0,,"この件について、ボーデシアが
 貴君に言いたいことがあるというのだ","Boadicea has something to tell you about this
 matter.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,44,Ciarán
@@ -176,16 +176,16 @@ has been detected by the enemy monsters.",ui\00_message\npc\base\n2700.gmd,\npc\
 0,,"《<SPOT 949>》に魔族が現れ
 我々の行く手を阻んでいる
 それどころか、この村に侵攻しようとする
-動きすらあるのだ","Fiends have appeared in 《<SPOT 949>》, blocking
-our path.
-Not only that, they are even trying to invade
-this village.
-There is movement, indeed.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,56,Ciarán
+動きすらあるのだ","Fiends have appeared in
+《<SPOT 949>》,
+blocking our path. Not only that,
+they are even trying to invade this village.
+I've been wary of their movements.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,56,Ciarán
 0,,"異国の――いや、白き竜の覚者よ
 我々が封印を解かんとしている間
 湧き出でる魔族を討伐してほしい――","O Arisen of the White Dragon,
-While we are in the process of unsealing, We ask
-that you subdue the surging Fiends.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,57,Ciarán
+While we are in the process of unsealing,
+We ask that you subdue the resurgent Fiends.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,57,Ciarán
 0,,"うまくいけば、あと少しで
 この騒動にも決着がつくはずなのだ――","If all goes well, there should be a resolution to
 this turmoil soon—just a little further to go.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,58,Ciarán
@@ -198,8 +198,8 @@ You have come at a good time!",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n
 at ""<SPOT 912>"", and we have finally succeeded!",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,60,Ciarán
 0,,"どうか、かの神殿に赴き
 魔族が活性化した理由を
-探ってきてもらえないだろうか","Please, visit the Temple and investigate the
-reason behind the Fiends' resurgence.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,61,Ciarán
+探ってきてもらえないだろうか","Please, visit the Temple and investigate
+the reason behind the Fiends' resurgence.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,61,Ciarán
 0,,"引き受けてもらえるのなら
 あの辺りの事情について詳しい者を
 貴君に紹介しよう
@@ -213,9 +213,9 @@ I appreciate it.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,63,C
 0,,"あれ以来は静かなものだ――
 侵食という災いはいまだ大地をむしばんでいるが
 忌まわしい魔族に脅かされることはない","Since then, it has been quiet—
-Though the calamity of corruption still gnaws at
-the land,
-We are not threatened by the loathsome fiends.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,64,Ciarán
+Though the calamity of corruption still gnaws
+at the land, we'll not be threatened
+by such loathsome abberations.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,64,Ciarán
 0,,"貴君には続けて世話になったな
 この辺りに来た時は、今日のように
 ぜひ村に寄ってくれ","I have relied on your kind assistance for some
@@ -273,9 +273,10 @@ people called <SPOT 959>.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700
 unique culture, so there are quite a few
 difficulties in communication.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,76,Ciarán
 0,,"昨今の魔族出現の件にて交渉を重ね、拠点として
-門戸を開放するよう約束を取り付けた","Through repeated negotiations regarding the
-recent appearance of Fiends, a promise was secured
-to open the gates and establish a Hall as a base.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,77,Ciarán
+門戸を開放するよう約束を取り付けた","Through repeated negotiations
+regarding the recent appearance of Fiends,
+a promise was secured to open the gates
+and establish a Hall as a base.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,77,Ciarán
 0,,"恐らく住民には歓迎されないだろうとは思うが
 《<SPOT 959>》を調査の足場として
 あるいは旅の疲れを癒すため
@@ -356,10 +357,10 @@ Thank you for coming.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc
 0,,"侵食という未曾有の災害に見舞われたフィンダム
 その中でも、さらに魔族の脅威に繰り返し
 さらされたグリンデュアが――今もこうして
-あるのは全て貴君の力添えあってこそ","Phindym, which was struck by the unprecedented
-disaster of Corruption, and Glyndwr, who has been
-repeatedly exposed to the threat of the Fiends, is
-still here today, thanks to all your support.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,93,Ciarán
+あるのは全て貴君の力添えあってこそ","Phindym was struck by the unprecedented
+disaster of Corruption. Even amidst that devastation,
+Glyndwr was relentlessly attacked by monstrosities,
+but is still here today, thanks to your support.",ui\00_message\npc\base\n2700.gmd,\npc\n2700.arc,n2700.arc,93,Ciarán
 0,,"これまでの礼として
 今後、貴君への支給品の質をより向上させる
 ことを決定した","As a token of gratitude so far, we have decided

--- a/English/Fully Translated/121.csv
+++ b/English/Fully Translated/121.csv
@@ -683,7 +683,7 @@ Hall",ui\00_message\package_quest\package_quest_sequence_01.gmd,\quest\package_q
 1,PACKAGE_QUEST_SEQUENCE_19,潜入調査―陽光照らすメガド―,Undercover -Sunlight Illuminating Megado-,ui\00_message\package_quest\package_quest_sequence_03.gmd,\quest\package_quest\seq_name_03.arc,seq_name_03.arc,1,
 2,PACKAGE_QUEST_SEQUENCE_20,諜報活動―闇夜覆うメガド―,"Intelligence Assessment
 -Dark Night Covering Megado-",ui\00_message\package_quest\package_quest_sequence_03.gmd,\quest\package_quest\seq_name_03.arc,seq_name_03.arc,2,
-3,PACKAGE_QUEST_SEQUENCE_21,第２の尋問―鍵握る悪鬼―,2nd Interrogation -Fiend Grasping a Key-,ui\00_message\package_quest\package_quest_sequence_03.gmd,\quest\package_quest\seq_name_03.arc,seq_name_03.arc,3,
+3,PACKAGE_QUEST_SEQUENCE_21,第２の尋問―鍵握る悪鬼―,2nd Interrogation -Demonic Keyholder-,ui\00_message\package_quest\package_quest_sequence_03.gmd,\quest\package_quest\seq_name_03.arc,seq_name_03.arc,3,
 4,PACKAGE_QUEST_SEQUENCE_22,潜入調査―誉れの侯爵 ナヴィド―,Undercover -Marquis of Honor Navid-,ui\00_message\package_quest\package_quest_sequence_03.gmd,\quest\package_quest\seq_name_03.arc,seq_name_03.arc,4,
 5,PACKAGE_QUEST_SEQUENCE_23,諜報活動―反旗翻す者たち―,Intelligence Assessment -People Rising in Revolt-,ui\00_message\package_quest\package_quest_sequence_03.gmd,\quest\package_quest\seq_name_03.arc,seq_name_03.arc,5,
 6,PACKAGE_QUEST_SEQUENCE_24,永き闇裂く者たち,Eternal Darkness Breakers,ui\00_message\package_quest\package_quest_sequence_03.gmd,\quest\package_quest\seq_name_03.arc,seq_name_03.arc,6,

--- a/English/Fully Translated/141.csv
+++ b/English/Fully Translated/141.csv
@@ -134,7 +134,7 @@ will not be harbored by evil!",ui\00_message\quest\q00020230.gmd,\quest\q0002023
 0,,他人に身を潜める卑怯者！　去れ！,"You coward who lurks in the shadows!
 Leave this place at once!",ui\00_message\quest\q00020230.gmd,\quest\q00020230.arc,q00020230.arc,41,Cecily
 0,,てめえの正体はなんだ！,What is your true identity!,ui\00_message\quest\q00020230.gmd,\quest\q00020230.arc,q00020230.arc,42,Gurdolin
-0,,この、けむり野郎め！,"You, wretched smoke fiend!",ui\00_message\quest\q00020230.gmd,\quest\q00020230.arc,q00020230.arc,43,Gurdolin
+0,,この、けむり野郎め！,"You smoky bastard!",ui\00_message\quest\q00020230.gmd,\quest\q00020230.arc,q00020230.arc,43,Gurdolin
 0,,騎士を名乗るんじゃねえ,You dare call yourself a knight?,ui\00_message\quest\q00020230.gmd,\quest\q00020230.arc,q00020230.arc,44,Gurdolin
 0,,おら、隊長！　なんとか言ってやれ！,"Hey, Captain!
 Tell him what for!",ui\00_message\quest\q00020230.gmd,\quest\q00020230.arc,q00020230.arc,45,Gurdolin

--- a/English/Fully Translated/145.csv
+++ b/English/Fully Translated/145.csv
@@ -601,7 +601,7 @@ Fight!",ui\00_message\quest\q00030200.gmd,\quest\q00030200.arc,q00030200.arc,58,
 0,,くそっ！　もどかしい！,Damn! This is frustrating!,ui\00_message\quest\q00030200.gmd,\quest\q00030200.arc,q00030200.arc,59,Gillian
 0,,さあさあさあ！,"Come on, come on!",ui\00_message\quest\q00030200.gmd,\quest\q00030200.arc,q00030200.arc,60,Elliot
 0,,今度こそ倒す！,This time we'll beat them!,ui\00_message\quest\q00030200.gmd,\quest\q00030200.arc,q00030200.arc,61,Elliot
-0,,邪魔な魔物め！,"Get away, you bothersome fiend!",ui\00_message\quest\q00030200.gmd,\quest\q00030200.arc,q00030200.arc,62,Elliot
+0,,邪魔な魔物め！,"Out of my way, you monsters!",ui\00_message\quest\q00030200.gmd,\quest\q00030200.arc,q00030200.arc,62,Elliot
 0,,俺が相手だ！　かかってこい！,I'm your opponent! Come on!,ui\00_message\quest\q00030200.gmd,\quest\q00030200.arc,q00030200.arc,63,Elliot
 0,,隊長、戦況が見えません！,"Captain, I can't see the battlefield!",ui\00_message\quest\q00030200.gmd,\quest\q00030200.arc,q00030200.arc,64,Elliot
 0,,くっ――逃げられる！,Damn―― they're getting away!,ui\00_message\quest\q00030200.gmd,\quest\q00030200.arc,q00030200.arc,65,Elliot
@@ -793,8 +793,8 @@ is the altar at the lowest level
 of the Detached Palace.",ui\00_message\quest\q00030210.gmd,\quest\q00030210.arc,q00030210.arc,39,Yuri
 0,,"だが、大地の衰えと共に離宮の中は
 邪悪な魔物で満たされてしまっている","But as the land has decayed, 
-the Detached Palace has been 
-filled with foul fiends.",ui\00_message\quest\q00030210.gmd,\quest\q00030210.arc,q00030210.arc,40,Yuri
+the Detached Palace found itself
+overrun with foul fiends.",ui\00_message\quest\q00030210.gmd,\quest\q00030210.arc,q00030210.arc,40,Yuri
 0,,十分に気をつけて進んでくれ！,Proceed with extreme caution!,ui\00_message\quest\q00030210.gmd,\quest\q00030210.arc,q00030210.arc,41,Yuri
 0,,わたしもさっき着いたんだ,I just got here too.,ui\00_message\quest\q00030210.gmd,\quest\q00030210.arc,q00030210.arc,42,Gillian
 0,,"王子の気持ちに寄り添っていたつもりだけど
@@ -1188,9 +1188,9 @@ with Sly, and here we are.",ui\00_message\quest\q00030220.gmd,\quest\q00030220.a
 0,,"彼女は隙を見て魔軍から逃げ出せたらしい
 でも魔物に追われている！
 スライが彼女を守りに行ったが
-ああ、このすぐ先だ！","Apparently she was able to escape from the 
-Demon Army when she saw an opening, 
-but she was still being chased by fiends!
+ああ、このすぐ先だ！","Apparently she was able to escape
+from the Demon Army when she saw an opening,
+but she was still being chased by monsters!
 Sly went to protect her.
 Yeah, it's just up ahead!",ui\00_message\quest\q00030220.gmd,\quest\q00030220.arc,q00030220.arc,69,Marten
 0,,"彼女から追手を引き離そうと、注意を引くつもり
@@ -1206,9 +1206,8 @@ So, she must be Cyril's daughter.",ui\00_message\quest\q00030220.gmd,\quest\q000
 0,,"さあ、連れて帰ろう
 魔物に襲われて怪我をしている
 言ってることも混乱気味だ","Come on, let's bring her home.
-She's been attacked by a fiend, 
-she's wounded and confused about what 
-she's saying.",ui\00_message\quest\q00030220.gmd,\quest\q00030220.arc,q00030220.arc,73,Sly
+She's been attacked by a beast.
+she's wounded and dazed.",ui\00_message\quest\q00030220.gmd,\quest\q00030220.arc,q00030220.arc,73,Sly
 0,,"――誰！？
 オークじゃないよね？","―― Who!?
 You're not an orc, are you?",ui\00_message\quest\q00030220.gmd,\quest\q00030220.arc,q00030220.arc,74,Ashe

--- a/English/Fully Translated/147.csv
+++ b/English/Fully Translated/147.csv
@@ -29,7 +29,7 @@ siphoned off is right here on the map.",ui\00_message\quest\q00030410.gmd,\quest
 0,,"来てくれたか
 黒剣は見つけたが、中には魔物がいる！","You're here.
 I found the Black Sword, 
-but there are fiends inside!",ui\00_message\quest\q00030410.gmd,\quest\q00030410.arc,q00030410.arc,58,Gawain
+but there are monsters inside!",ui\00_message\quest\q00030410.gmd,\quest\q00030410.arc,q00030410.arc,58,Gawain
 0,,頼む、力を貸してくれ！,"Please, I need your help!",ui\00_message\quest\q00030410.gmd,\quest\q00030410.arc,q00030410.arc,59,Gawain
 0,,"見事だ、覚者殿！
 この場所での竜力の吸い上げは止んだようだ","Excellent, Master Arisen!
@@ -505,7 +505,7 @@ I thought it was about time you joined us.
 Many thanks for your time.",ui\00_message\quest\q00030420.gmd,\quest\q00030420.arc,q00030420.arc,17,Nedo
 0,,フィンダムの時と同じだな,It's just like in Phindym.,ui\00_message\quest\q00030420.gmd,\quest\q00030420.arc,q00030420.arc,18,Gurdolin
 0,,黒剣が刺さってて、そこに魔物が集まるんだ,"A Black Sword is thrust into it, 
-and that's where the fiends congregate.",ui\00_message\quest\q00030420.gmd,\quest\q00030420.arc,q00030420.arc,19,Gurdolin
+and that's where the monsters congregate.",ui\00_message\quest\q00030420.gmd,\quest\q00030420.arc,q00030420.arc,19,Gurdolin
 0,,"隊長、急ごうよ
 きっとジリアンも戦ってるよ","Captain, let's hurry.
 I'm sure Gillian is fighting too.",ui\00_message\quest\q00030420.gmd,\quest\q00030420.arc,q00030420.arc,20,Lise
@@ -657,7 +657,7 @@ Thank you.",ui\00_message\quest\q00030420.gmd,\quest\q00030420.arc,q00030420.arc
 0,,あんたに命を救われたのは、これで何度目だろうか,How many times have you saved my life now?,ui\00_message\quest\q00030420.gmd,\quest\q00030420.arc,q00030420.arc,67,Liberation Army Soldier
 0,,"ははっ
 魔物どもめ！　俺はまだ、倒れちゃねーぞ――","Ha ha!
-You fiends!　I ain't going down yet――",ui\00_message\quest\q00030420.gmd,\quest\q00030420.arc,q00030420.arc,68,Liberation Army Soldier
+You monsters!　I ain't going down yet――",ui\00_message\quest\q00030420.gmd,\quest\q00030420.arc,q00030420.arc,68,Liberation Army Soldier
 0,,これを見てくれ――,Take a look at this――,ui\00_message\quest\q00030420.gmd,\quest\q00030420.arc,q00030420.arc,69,Liberation Army Soldier
 0,,"剣はこうして折られたが
 奴らは、俺の心までも砕くことは出来なかったようだ","The sword was broken like this, 
@@ -1068,9 +1068,10 @@ and I need you to hurry up and
 get to Commander Gerd.",ui\00_message\quest\q00030430.gmd,\quest\q00030430.arc,q00030430.arc,46,Heinz
 0,,"俺たちの被害がこの程度で済んだのは
 団長の部隊が魔物を引き付けようと
-派手に戦ってくれたおかげだ","The only reason we got away with this little 
-damage was because the Commander's troops 
-fought so spectacularly to attract the fiends.",ui\00_message\quest\q00030430.gmd,\quest\q00030430.arc,q00030430.arc,47,Heinz
+派手に戦ってくれたおかげだ","The only reason we were able to get away
+with this little damage was because
+the Commander's troops fought so spectacularly
+to split their forces.",ui\00_message\quest\q00030430.gmd,\quest\q00030430.arc,q00030430.arc,47,Heinz
 0,,"だが今回ばかりは、これまでのように
 どうにかなる状況とは思えない
 団長もそれを感じ、囮を買ってくれたのだ","But I think this time around, the situation 
@@ -1095,17 +1096,17 @@ No, we have no other choice but to rely on you!",ui\00_message\quest\q00030430.g
 0,,深手を負ったようだ――,I think I've taken a grave wound--,ui\00_message\quest\q00030430.gmd,\quest\q00030430.arc,q00030430.arc,54,White Knight
 0,,"俺に構わず、レスタニアを魔物から守ってくれ――
 頼んだぞ――","I don't care what happens to me, 
-you protect Lestania from the fiends――
+you protect Lestania from the demons――
 I'm counting on you――",ui\00_message\quest\q00030430.gmd,\quest\q00030430.arc,q00030430.arc,55,White Knight
 0,,"貴殿ら、どうしてここに――
 そうかハインツか、要らぬ気遣いを――","You guys, why are you here――
 Ah, Heinz, always a worrier――",ui\00_message\quest\q00030430.gmd,\quest\q00030430.arc,q00030430.arc,56,Gerd
 0,,"我々騎士団は多大な犠牲を払って
 黒騎士のものと思しき黒い剣に
-集まる魔物どもを撃破した","We, the Knight's Order, have at great cost 
-defeated the fiends that gathered around the 
-Black Sword, believed to belong to the 
-Black Knight.",ui\00_message\quest\q00030430.gmd,\quest\q00030430.arc,q00030430.arc,57,Gerd
+集まる魔物どもを撃破した","We, the Knight's Order,
+have at great cost defeated the enemy
+that were gathered around the Black Sword,
+believed to belong to the Black Knight.",ui\00_message\quest\q00030430.gmd,\quest\q00030430.arc,q00030430.arc,57,Gerd
 0,,"今頃はドリード城に貴殿らの言う
 ゲートが現れようとしていることだろう
 そこから先の闇の世界では
@@ -1158,8 +1159,8 @@ gate leading to the vortex, and secure it.",ui\00_message\quest\q00030430.gmd,\q
 darkness, the more holding on will drain us.",ui\00_message\quest\q00030430.gmd,\quest\q00030430.arc,q00030430.arc,72,Vanessa
 0,,あまり待たせるなよ,Don't keep us waiting too long.,ui\00_message\quest\q00030430.gmd,\quest\q00030430.arc,q00030430.arc,73,Vanessa
 0,,"我々も、闇の波動の弱体化のため
-城内の魔物を掃討しつつ探索を行う","We, too, will search the castle while clearing 
-out the fiends in order to weaken 
+城内の魔物を掃討しつつ探索を行う","We, too, will search the castle
+and clear out the enemy in order to weaken
 the surge of darkness.",ui\00_message\quest\q00030430.gmd,\quest\q00030430.arc,q00030430.arc,74,Vanessa
 0,,わたしは掃討の方が、好みだがな,I prefer sweeping up.,ui\00_message\quest\q00030430.gmd,\quest\q00030430.arc,q00030430.arc,75,Vanessa
 0,,"ファビオから聞いたよ

--- a/English/Fully Translated/148.csv
+++ b/English/Fully Translated/148.csv
@@ -353,7 +353,7 @@ I'm not sure what it is, but I'm sure it's there.",ui\00_message\quest\q00030440
 0,,テオドール様が次の場所に向かわれた,Master Theodor has moved on to the next location.,ui\00_message\quest\q00030440.gmd,\quest\q00030440.arc,q00030440.arc,52,Iosef
 0,,"ここと同じく、辺りは闇の魔物で溢れている
 急いで欲しい","Like here, the area is full of all sorts of 
-dark fiends, so we need you to hurry.",ui\00_message\quest\q00030440.gmd,\quest\q00030440.arc,q00030440.arc,53,Iosef
+dark creatures, so we need you to hurry.",ui\00_message\quest\q00030440.gmd,\quest\q00030440.arc,q00030440.arc,53,Iosef
 0,,"これで、亡都メルゴダに突き立てられた黒剣は
 すべて破壊できた","With this, we have destroyed all the Black Swords 
 that have been thrust upon the Mergoda Ruins.",ui\00_message\quest\q00030440.gmd,\quest\q00030440.arc,q00030440.arc,54,Theodor
@@ -367,8 +367,8 @@ which is plunged into darkness.",ui\00_message\quest\q00030440.gmd,\quest\q00030
 入口へ向かっている","Your people are already on their way to the 
 entrance of the Mergoda Security District.",ui\00_message\quest\q00030440.gmd,\quest\q00030440.arc,q00030440.arc,56,Theodor
 0,,"さあ、残りの魔物はわたしたちに任せてくれ
-仲間の元へ行くと良い","Now, leave the rest of the fiends to us.
-Go to your comrades.",ui\00_message\quest\q00030440.gmd,\quest\q00030440.arc,q00030440.arc,57,Theodor
+仲間の元へ行くと良い","Now, leave the rest of them to us.
+Go now, to your comrades.",ui\00_message\quest\q00030440.gmd,\quest\q00030440.arc,q00030440.arc,57,Theodor
 0,,"このわたしにも、魔物と戦う力が
 まだ残っていようとはな","I can't believe I still have the power to 
 battle the beasts.",ui\00_message\quest\q00030440.gmd,\quest\q00030440.arc,q00030440.arc,58,Theodor
@@ -1085,7 +1085,7 @@ so I guess they're in the vicinity, but...",ui\00_message\quest\q10300104.gmd,\q
 ティネス砦への物資運搬中に
 魔物が襲ってきたんだ！","Just in time!
 We were hauling supplies to Fort Thines 
-when the fiends attacked us!",ui\00_message\quest\q10300104.gmd,\quest\q10300104.arc,q10300104.arc,15,Lorna
+when the monsters attacked us!",ui\00_message\quest\q10300104.gmd,\quest\q10300104.arc,q10300104.arc,15,Lorna
 0,,"この先の桟橋で仲間が戦ってる
 彼も少し負傷して、うまく動けてない
 手を貸して――！","My buddy's fighting on the pier up ahead, 

--- a/English/Fully Translated/192.csv
+++ b/English/Fully Translated/192.csv
@@ -564,7 +564,7 @@ that can be used for interrogation",ui\00_message\quest_info\q10320301_00.gmd,\q
 Extract information related to <NPC 681>",ui\00_message\quest_info\q10320400_00.gmd,\quest\q10320400.arc,q10320400.arc,1,Mephis
 2,q10320400_00_4339,メフィスに話しかけ、尋問を行う,Speak with Mephis and conduct an interrogation,ui\00_message\quest_info\q10320400_00.gmd,\quest\q10320400.arc,q10320400.arc,2,Mephis
 3,q10320400_00_4340,メフィスに報告する,Report to Mephis,ui\00_message\quest_info\q10320400_00.gmd,\quest\q10320400.arc,q10320400.arc,3,Mephis
-0,q10320401_00_55,【尋問】鍵握る悪鬼,Interrogation: Fiend Grasping a Key,ui\00_message\quest_info\q10320401_00.gmd,\quest\q10320401.arc,q10320401.arc,0,Mephis
+0,q10320401_00_55,【尋問】鍵握る悪鬼,Interrogation: Demonic Keyholder,ui\00_message\quest_info\q10320401_00.gmd,\quest\q10320401.arc,q10320401.arc,0,Mephis
 1,q10320401_00_55,"<NPC 682>を尋問し
 <NPC 681>に関わる情報を引き出す","Interrogate <NPC 682>
 Extract information related to <NPC 681>",ui\00_message\quest_info\q10320401_00.gmd,\quest\q10320401.arc,q10320401.arc,1,Mephis

--- a/English/Fully Translated/197.csv
+++ b/English/Fully Translated/197.csv
@@ -1110,7 +1110,7 @@ Oh? Partner, you're here!
 Wait, you never said we were 
 hunting monsters, did you? 
 Then what exactly were we doing?",ui\00_message\quest_info\q21000025_00.gmd,\quest\q21000025.arc,q21000025.arc,3,
-4,q21000025_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000025_00.gmd,\quest\q21000025.arc,q21000025.arc,4,
+4,q21000025_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000025_00.gmd,\quest\q21000025.arc,q21000025.arc,4,
 0,q21000026_00_338,【宝飾の扉】現れた巨像,Door of Jewelry: Emerged Colossus,ui\00_message\quest_info\q21000026_00.gmd,\quest\q21000026.arc,q21000026.arc,0,
 1,q21000026_00_338,"【危険区域クエスト】
 ダンジョン内の危険区域へ繋がる扉の鍵を作り
@@ -1135,4 +1135,4 @@ I swear I'll never go near
 such a place again. 
 Curiosity? That can always be 
 shattered against the weight of life.",ui\00_message\quest_info\q21000026_00.gmd,\quest\q21000026.arc,q21000026.arc,3,
-4,q21000026_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000026_00.gmd,\quest\q21000026.arc,q21000026.arc,4,
+4,q21000026_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000026_00.gmd,\quest\q21000026.arc,q21000026.arc,4,

--- a/English/Fully Translated/198.csv
+++ b/English/Fully Translated/198.csv
@@ -20,7 +20,7 @@ But strangely, I wasn't scared.
 It was floating and glowing softly— 
 if my mom hadn't called me, 
 I might have followed it.",ui\00_message\quest_info\q21000027_00.gmd,\quest\q21000027.arc,q21000027.arc,3,
-4,q21000027_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000027_00.gmd,\quest\q21000027.arc,q21000027.arc,4,
+4,q21000027_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000027_00.gmd,\quest\q21000027.arc,q21000027.arc,4,
 0,q21000028_00_340,【宝飾の扉】悪夢の根源,【Door of Jewelry】The Source of the Nightmare,ui\00_message\quest_info\q21000028_00.gmd,\quest\q21000028.arc,q21000028.arc,0,
 1,q21000028_00_340,"【危険区域クエスト】
 ダンジョン内の危険区域へ繋がる扉の鍵を作り
@@ -43,7 +43,7 @@ and there it was, a monster I'd never seen!
 Now, I can't sleep at night, 
 haunted by nightmares. 
 Someone, please help me!",ui\00_message\quest_info\q21000028_00.gmd,\quest\q21000028.arc,q21000028.arc,3,
-4,q21000028_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000028_00.gmd,\quest\q21000028.arc,q21000028.arc,4,
+4,q21000028_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000028_00.gmd,\quest\q21000028.arc,q21000028.arc,4,
 0,q21000029_00_341,棄てられた獲物,Abandoned Prey,ui\00_message\quest_info\q21000029_00.gmd,\quest\q21000029.arc,q21000029.arc,0,
 1,q21000029_00_341,"【討伐クエスト】
 エリアに出現した怪しい魔物を探し
@@ -327,7 +327,7 @@ Guilty."" Deep within lies an
 incredibly fierce creature. Many 
 capable warriors have ventured in, 
 but none have come back.",ui\00_message\quest_info\q21000039_00.gmd,\quest\q21000039.arc,q21000039.arc,3,
-4,q21000039_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000039_00.gmd,\quest\q21000039.arc,q21000039.arc,4,
+4,q21000039_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000039_00.gmd,\quest\q21000039.arc,q21000039.arc,4,
 0,q21000040_00_352,呪われし聖域,The Cursed Sanctuary,ui\00_message\quest_info\q21000040_00.gmd,\quest\q21000040.arc,q21000040.arc,0,
 1,q21000040_00_352,"【討伐クエスト】
 エリアに出現した怪しい魔物を探し
@@ -377,7 +377,7 @@ In truth, it shouldn't be such a
 big deal, but I wonder why that is. 
 Could it be that I really love this 
 forest after all?",ui\00_message\quest_info\q21000041_00.gmd,\quest\q21000041.arc,q21000041.arc,3,
-4,q21000041_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000041_00.gmd,\quest\q21000041.arc,q21000041.arc,4,
+4,q21000041_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000041_00.gmd,\quest\q21000041.arc,q21000041.arc,4,
 0,q21000042_00_354,職人気質,Spirit of a Craftsman,ui\00_message\quest_info\q21000042_00.gmd,\quest\q21000042.arc,q21000042.arc,0,Raul
 1,q21000042_00_354,"【死亡チェッククエスト】
 依頼者の願いを聞き入れ
@@ -483,7 +483,7 @@ monsters together until we met that beast—
 we should have only dealt with monsters 
 that matched our own strength. 
 Even now, such regrets haunt my heart.",ui\00_message\quest_info\q21000045_00.gmd,\quest\q21000045.arc,q21000045.arc,3,
-4,q21000045_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000045_00.gmd,\quest\q21000045.arc,q21000045.arc,4,
+4,q21000045_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000045_00.gmd,\quest\q21000045.arc,q21000045.arc,4,
 0,q21000046_00_358,遠方より想う,A Yearning from a Distance,ui\00_message\quest_info\q21000046_00.gmd,\quest\q21000046.arc,q21000046.arc,0,Gunther
 1,q21000046_00_358,"【納品クエスト】
 依頼者の願いを聞き入れ
@@ -579,7 +579,7 @@ haven't seen it for myself, there's no doubt
 a truly terrifying monster is out there. 
 Something that could easily swallow you whole— 
 ah, but yeah, I haven't actually seen it, though.",ui\00_message\quest_info\q21000049_00.gmd,\quest\q21000049.arc,q21000049.arc,3,
-4,q21000049_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000049_00.gmd,\quest\q21000049.arc,q21000049.arc,4,
+4,q21000049_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000049_00.gmd,\quest\q21000049.arc,q21000049.arc,4,
 0,q21000050_00_369,郷土愛の痛み,Missing One's Hometown,ui\00_message\quest_info\q21000050_00.gmd,\quest\q21000050.arc,q21000050.arc,0,Mubarak
 1,q21000050_00_369,"【納品討伐クエスト】
 依頼者に高価なアイテムを渡し

--- a/English/Fully Translated/199.csv
+++ b/English/Fully Translated/199.csv
@@ -102,7 +102,7 @@ are necessary. It was a good chance
 to understand my current strength. 
 I consider myself fortunate to have 
 survived this encounter.",ui\00_message\quest_info\q21000076_00.gmd,\quest\q21000076.arc,q21000076.arc,3,
-4,q21000076_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000076_00.gmd,\quest\q21000076.arc,q21000076.arc,4,
+4,q21000076_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000076_00.gmd,\quest\q21000076.arc,q21000076.arc,4,
 0,q21000077_00_396,【財宝の扉】愚者葬られし場,【Door of Treasures】The Fool's Burial Ground,ui\00_message\quest_info\q21000077_00.gmd,\quest\q21000077.arc,q21000077.arc,0,
 1,q21000077_00_396,"【危険区域クエスト】
 ダンジョン内の危険区域へ繋がる扉の鍵を作り
@@ -125,7 +125,7 @@ into a magic realm filled with
 evil creatures. Many fools, 
 dazzled by the chance to make 
 a quick fortune, have lost their lives.",ui\00_message\quest_info\q21000077_00.gmd,\quest\q21000077.arc,q21000077.arc,3,
-4,q21000077_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000077_00.gmd,\quest\q21000077.arc,q21000077.arc,4,
+4,q21000077_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000077_00.gmd,\quest\q21000077.arc,q21000077.arc,4,
 0,q21000078_00_397,【宝飾の扉】異物排除,【Door of Jewelry】Eliminate Invaders,ui\00_message\quest_info\q21000078_00.gmd,\quest\q21000078.arc,q21000078.arc,0,
 1,q21000078_00_397,"【危険区域クエスト】
 ダンジョン内の危険区域へ繋がる扉の鍵を作り
@@ -143,7 +143,7 @@ a special key can enter.",ui\00_message\quest_info\q21000078_00.gmd,\quest\q2100
 It seemed to be coming from ""Gardnox Fortress."" 
 It was a bad smell. Perhaps the drainage failed? 
 They should hurry up and repair it.",ui\00_message\quest_info\q21000078_00.gmd,\quest\q21000078.arc,q21000078.arc,3,
-4,q21000078_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000078_00.gmd,\quest\q21000078.arc,q21000078.arc,4,
+4,q21000078_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000078_00.gmd,\quest\q21000078.arc,q21000078.arc,4,
 0,q21000079_00_398,珠玉を求む,In Search of Gems,ui\00_message\quest_info\q21000079_00.gmd,\quest\q21000079.arc,q21000079.arc,0,Ariadne
 1,q21000079_00_398,"【納品討伐クエスト】
 依頼者に高価なアイテムを渡し
@@ -359,7 +359,7 @@ There was this massive monster,
 and I knocked it out with my iron fists! 
 Huh? The bandage on my head? It's my trophy! 
 I don't remember a thing after delivering that punch, though.",ui\00_message\quest_info\q21000087_00.gmd,\quest\q21000087.arc,q21000087.arc,3,
-4,q21000087_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000087_00.gmd,\quest\q21000087.arc,q21000087.arc,4,
+4,q21000087_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000087_00.gmd,\quest\q21000087.arc,q21000087.arc,4,
 0,q21000088_00_407,懐かしき日,The Good Old Days,ui\00_message\quest_info\q21000088_00.gmd,\quest\q21000088.arc,q21000088.arc,0,Theodor
 1,q21000088_00_407,"【死亡チェッククエスト】
 依頼者の願いを聞き入れ
@@ -447,7 +447,7 @@ but it was surrounded by a malevolent force that repelled people.
 At that moment, the research team decided to turn back― 
 there's probably a dreadful monster hiding there. 
 The locals should never go near it.",ui\00_message\quest_info\q21000091_00.gmd,\quest\q21000091.arc,q21000091.arc,3,
-4,q21000091_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000091_00.gmd,\quest\q21000091.arc,q21000091.arc,4,
+4,q21000091_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000091_00.gmd,\quest\q21000091.arc,q21000091.arc,4,
 0,q21000092_00_365,強欲の結末,An End to Greed,ui\00_message\quest_info\q21000092_00.gmd,\quest\q21000092.arc,q21000092.arc,0,
 1,q21000092_00_365,"【討伐クエスト】
 エリアに出現した怪しい魔物を探し
@@ -540,7 +540,7 @@ a fair bit of cash.
 I can't just sit around; will someone partner with me 
 for a monster hunt? 
 Naturally, I'll take all the loot.",ui\00_message\quest_info\q21000095_00.gmd,\quest\q21000095.arc,q21000095.arc,3,
-4,q21000095_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000095_00.gmd,\quest\q21000095.arc,q21000095.arc,4,
+4,q21000095_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000095_00.gmd,\quest\q21000095.arc,q21000095.arc,4,
 0,q21000096_00_415,悪夢の象徴,A Sign of Nightmares,ui\00_message\quest_info\q21000096_00.gmd,\quest\q21000096.arc,q21000096.arc,0,Clarissa
 1,q21000096_00_415,"【死亡チェッククエスト】
 依頼者の願いを聞き入れ
@@ -632,7 +632,7 @@ so I was planning to hunt a rabbit—
 but what on earth was that beast? 
 Would it be delicious if roasted? 
 It seems like it could be a bit pungent.",ui\00_message\quest_info\q21000099_00.gmd,\quest\q21000099.arc,q21000099.arc,3,
-4,q21000099_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21000099_00.gmd,\quest\q21000099.arc,q21000099.arc,4,
+4,q21000099_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21000099_00.gmd,\quest\q21000099.arc,q21000099.arc,4,
 0,q21013000_00_530,【2.2WQ】孤島,【2.2WQ】Solitary island,ui\00_message\quest_info\q21013000_00.gmd,\quest\q21013000.arc,q21013000.arc,0,
 0,q21014000_00_540,守り人を守る人,Protecting the Protectors,ui\00_message\quest_info\q21014000_00.gmd,\quest\q21014000.arc,q21014000.arc,0,Dirith
 1,q21014000_00_540,"【敵群討伐クエスト】
@@ -814,7 +814,7 @@ I'm curious when it started to change like this.
 Not long ago, I heard a strange, eerie sound 
 that I had never encountered. Will the monsters 
 eventually overrun the entire forest?",ui\00_message\quest_info\q21014007_00.gmd,\quest\q21014007.arc,q21014007.arc,3,
-4,q21014007_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21014007_00.gmd,\quest\q21014007.arc,q21014007.arc,4,
+4,q21014007_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21014007_00.gmd,\quest\q21014007.arc,q21014007.arc,4,
 0,q21014008_00_548,胡乱の目撃者,A Suspicious Eyewitness,ui\00_message\quest_info\q21014008_00.gmd,\quest\q21014008.arc,q21014008.arc,0,Enna
 1,q21014008_00_548,"【敵群討伐クエスト】
 依頼者から話を聞き

--- a/English/Fully Translated/200.csv
+++ b/English/Fully Translated/200.csv
@@ -179,7 +179,7 @@ arrogant for a monster. They say
 it's quite ferocious, but if we can 
 defeat it, we might get something 
 really valuable in return.",ui\00_message\quest_info\q21014024_00.gmd,\quest\q21014024.arc,q21014024.arc,3,
-4,q21014024_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21014024_00.gmd,\quest\q21014024.arc,q21014024.arc,4,
+4,q21014024_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21014024_00.gmd,\quest\q21014024.arc,q21014024.arc,4,
 0,q21015000_00_588,看板娘の小手調べ,The Store Girl's Trials,ui\00_message\quest_info\q21015000_00.gmd,\quest\q21015000.arc,q21015000.arc,0,Evey
 1,q21015000_00_588,"【敵群討伐クエスト】
 依頼者から話を聞き
@@ -370,7 +370,7 @@ because they are chased by monsters,
 or if monsters grew stronger because 
 they are pursued by warriors is a mystery 
 to everyone.",ui\00_message\quest_info\q21015007_00.gmd,\quest\q21015007.arc,q21015007.arc,3,
-4,q21015007_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21015007_00.gmd,\quest\q21015007.arc,q21015007.arc,4,
+4,q21015007_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21015007_00.gmd,\quest\q21015007.arc,q21015007.arc,4,
 0,q21015008_00_596,弱腰の矜持,Pride of the Weak,ui\00_message\quest_info\q21015008_00.gmd,\quest\q21015008.arc,q21015008.arc,0,Flannan
 1,q21015008_00_596,"【敵群討伐クエスト】
 依頼者から話を聞き
@@ -827,7 +827,7 @@ waterways, don't you? They've battled
 many warriors and travelers, 
 surviving as fierce veterans. 
 They must have amassed quite a fortune.",ui\00_message\quest_info\q21015024_00.gmd,\quest\q21015024.arc,q21015024.arc,3,
-4,q21015024_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21015024_00.gmd,\quest\q21015024.arc,q21015024.arc,4,
+4,q21015024_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21015024_00.gmd,\quest\q21015024.arc,q21015024.arc,4,
 0,q21016000_00_572,騒ぎの原因,Source of Disturbance,ui\00_message\quest_info\q21016000_00.gmd,\quest\q21016000.arc,q21016000.arc,0,Sloane
 1,q21016000_00_572,"【敵群討伐クエスト】
 依頼者から話を聞き
@@ -1031,7 +1031,7 @@ corruption magic have been
 discovered. It seems we need to 
 investigate the conditions 
 in various locations.",ui\00_message\quest_info\q21016007_00.gmd,\quest\q21016007.arc,q21016007.arc,3,
-4,q21016007_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21016007_00.gmd,\quest\q21016007.arc,q21016007.arc,4,
+4,q21016007_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21016007_00.gmd,\quest\q21016007.arc,q21016007.arc,4,
 0,q21016008_00_580,蝕鳥たちの舞,Flight of the Ravenous Birds ,ui\00_message\quest_info\q21016008_00.gmd,\quest\q21016008.arc,q21016008.arc,0,
 1,q21016008_00_580,"【討伐クエスト】
 エリアに出現した怪しい魔物を探し

--- a/English/Fully Translated/201.csv
+++ b/English/Fully Translated/201.csv
@@ -319,7 +319,7 @@ When I tried to chase it, my father stopped me,
 saying, ""You might become infected."" 
 I wonder if that odd bird is collecting 
 beautiful things?",ui\00_message\quest_info\q21016024_00.gmd,\quest\q21016024.arc,q21016024.arc,3,
-4,q21016024_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21016024_00.gmd,\quest\q21016024.arc,q21016024.arc,4,
+4,q21016024_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21016024_00.gmd,\quest\q21016024.arc,q21016024.arc,4,
 0,q21017000_00_556,食堂の危機,Dining Danger,ui\00_message\quest_info\q21017000_00.gmd,\quest\q21017000.arc,q21017000.arc,0,Shena
 1,q21017000_00_556,"【敵群討伐クエスト】
 依頼者から話を聞き
@@ -516,7 +516,7 @@ A hideous, grotesque monster—
 Anyone would think so upon seeing it. 
 It's likely been called ugly forever. 
 When I consider that, I can't help but feel pity.",ui\00_message\quest_info\q21017007_00.gmd,\quest\q21017007.arc,q21017007.arc,3,
-4,q21017007_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21017007_00.gmd,\quest\q21017007.arc,q21017007.arc,4,
+4,q21017007_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21017007_00.gmd,\quest\q21017007.arc,q21017007.arc,4,
 0,q21017008_00_564,長考の種,Seeds of Contemplation ,ui\00_message\quest_info\q21017008_00.gmd,\quest\q21017008.arc,q21017008.arc,0,Adelin
 1,q21017008_00_564,"【敵群討伐クエスト】
 依頼者から話を聞き
@@ -964,7 +964,7 @@ Damn! Being stationed in Kingal was supposed
 to keep me safe from the Corruption!
 You think beating it will make me stronger...?
 That has nothing to do with me!",ui\00_message\quest_info\q21017024_00.gmd,\quest\q21017024.arc,q21017024.arc,3,
-4,q21017024_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q21017024_00.gmd,\quest\q21017024.arc,q21017024.arc,4,
+4,q21017024_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q21017024_00.gmd,\quest\q21017024.arc,q21017024.arc,4,
 0,q22018000_00_640,弱り目に盗み目,Another Misfortune,ui\00_message\quest_info\q22018000_00.gmd,\quest\q22018000.arc,q22018000.arc,0,Bruno
 1,q22018000_00_640,"【敵群討伐クエスト】
 依頼者から話を聞き

--- a/English/Fully Translated/203.csv
+++ b/English/Fully Translated/203.csv
@@ -549,7 +549,7 @@ a special key can enter.",ui\00_message\quest_info\q29999993_00.gmd,\quest\q2999
 １２３４５６７８９０１２３４５６７８９０１２３４５６７
 １２３４５６７８９０１２３４５６７８９０１２３４５６７
 １２３４５６７８９０１２３４５６７８９０１２３４５６７",ui\00_message\quest_info\q29999993_00.gmd,\quest\q29999993.arc,q29999993.arc,3,Kieshildt
-4,q29999993_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered fiendish demons,ui\00_message\quest_info\q29999993_00.gmd,\quest\q29999993.arc,q29999993.arc,4,
+4,q29999993_00_1170,遭遇した凶悪な魔物を討伐する,Defeat the encountered monstrosities,ui\00_message\quest_info\q29999993_00.gmd,\quest\q29999993.arc,q29999993.arc,4,
 0,q29999994_00_302,須田テスト用クエスト,unused,ui\00_message\quest_info\q29999994_00.gmd,\quest\q29999994.arc,q29999994.arc,0,Myra
 1,q29999994_00_302,"依頼者の願いを聞き入れ
 対象の敵を討伐する","Listen to the client's request

--- a/English/Fully Translated/208.csv
+++ b/English/Fully Translated/208.csv
@@ -326,7 +326,7 @@ boosts the rewards you receive for completing missions.",ui\00_message\quest_inf
 5,q50101021_00_3777,先へ進む,Move forward,ui\00_message\quest_info\q50101021_00.gmd,\quest\q50101021.arc,q50101021.arc,5,
 6,q50101021_00_3778,３つ目の門を塞ぐ魔物を倒す,Defeat the demons blocking the 3rd gate,ui\00_message\quest_info\q50101021_00.gmd,\quest\q50101021.arc,q50101021.arc,6,
 7,q50101021_00_3785,先へ進む,Move forward,ui\00_message\quest_info\q50101021_00.gmd,\quest\q50101021.arc,q50101021.arc,7,
-8,q50101021_00_3786,悪魔を倒す,Defeat the fiend,ui\00_message\quest_info\q50101021_00.gmd,\quest\q50101021.arc,q50101021.arc,8,
+8,q50101021_00_3786,悪魔を倒す,Defeat the demon,ui\00_message\quest_info\q50101021_00.gmd,\quest\q50101021.arc,q50101021.arc,8,
 0,q50102000_00_41,古き力に魅かれし者,Drawn to Ancient Power,ui\00_message\quest_info\q50102000_00.gmd,\quest\q50102000.arc,q50102000.arc,0,
 1,q50102000_00_41,"竜の翼たる歴戦の覚者たちよ
 古き祭祀場にて、指輪に吸い寄せられし

--- a/English/Fully Translated/263.csv
+++ b/English/Fully Translated/263.csv
@@ -803,5 +803,5 @@ from the north, Arisen Leo leads the way,
 and Deputy Commander Vanessa
 leads the frontline unit. Once again,
 personnel have been recruited to join these forces.
-Through coordinated tactics,
-let's bury those fiends and protect the peace of Lestania.",ui\00_message\cycle_quest\cycle_quest_info1-1001.gmd,\quest\qci_01_1001.arc,qci_01_1001.arc,1,
+Through coordinated tactics, defeat them
+and protect the peace of Lestania.",ui\00_message\cycle_quest\cycle_quest_info1-1001.gmd,\quest\qci_01_1001.arc,qci_01_1001.arc,1,

--- a/English/splits/138.csv
+++ b/English/splits/138.csv
@@ -1038,10 +1038,10 @@ intends to interfere in this matter,
 then we ought to discuss some things first.",ui\00_message\quest\q00020050.gmd,\quest\q00020050.arc,q00020050.arc,33,Joseph
 0,,"結構ぶっ倒したってのに侵食魔どもは
 まだまだ暴れていやがる
-なのに、騎士団連中は救援要請に応え切れてねえ","We've defeated a good number of them, 
-but the encroaching fiends continue 
-to wreak havoc. Still, the Knight's Order
-hasn't fully answered the call for help.",ui\00_message\quest\q00020060.gmd,\quest\q00020060.arc,q00020060.arc,0,Gurdolin
+なのに、騎士団連中は救援要請に応え切れてねえ","Despite having put down a number of 'em,
+these corrupted beasts are still wreaking havoc.
+Still, the Knight's Order hasn't yet answered
+all requests for aid, eh?",ui\00_message\quest\q00020060.gmd,\quest\q00020060.arc,q00020060.arc,0,Gurdolin
 0,,"騎士団からまた応援を依頼されるのも
 時間の問題だろうよ","It won't be long before the knights 
 ask for reinforcements again.",ui\00_message\quest\q00020060.gmd,\quest\q00020060.arc,q00020060.arc,1,Gurdolin

--- a/English/splits/144.csv
+++ b/English/splits/144.csv
@@ -1117,7 +1117,7 @@ Whilst it flows――thou must make use of it――",ui\00_message\quest\q000301
 in battle with the Golden Dragon--",ui\00_message\quest\q00030170.gmd,\quest\q00030170.arc,q00030170.arc,36,Joseph
 0,,"白竜の力は衰え
 その結果、悪しき魔物が力をつけた","The White Dragon's power waned, 
-and as a result, the evil fiend gained strength.",ui\00_message\quest\q00030170.gmd,\quest\q00030170.arc,q00030170.arc,37,Joseph
+and as a result, the hellion gained strength.",ui\00_message\quest\q00030170.gmd,\quest\q00030170.arc,q00030170.arc,37,Joseph
 0,,"幸いにして覚者、騎士団の献身により
 白竜は命を繋ぎ、事なきを得たが――","Fortunately, thanks to the dedication of the 
 Arisen and the Knights, the White Dragon 

--- a/English/splits/146.csv
+++ b/English/splits/146.csv
@@ -927,7 +927,7 @@ are giving out!?",ui\00_message\quest\q00030260.gmd,\quest\q00030260.arc,q000302
 You just say whatever you want!",ui\00_message\quest\q00030260.gmd,\quest\q00030260.arc,q00030260.arc,79,Lise
 0,,火竜の無念、王子の代わりに晴らすんだから！,"I shall clear the Fire Dragon's grudge, 
 in the prince's stead!",ui\00_message\quest\q00030260.gmd,\quest\q00030260.arc,q00030260.arc,80,Lise
-0,,魔物の目的なんてどうでもいい！,I don't care what the fiend's purpose is!,ui\00_message\quest\q00030260.gmd,\quest\q00030260.arc,q00030260.arc,81,Lise
+0,,魔物の目的なんてどうでもいい！,I don't care what its purpose is!,ui\00_message\quest\q00030260.gmd,\quest\q00030260.arc,q00030260.arc,81,Lise
 0,,もう充分楽しんだでしょ！,You've had enough fun!,ui\00_message\quest\q00030260.gmd,\quest\q00030260.arc,q00030260.arc,82,Lise
 0,,ガルドリン、行け行け！,"Gurdolin, go, go!",ui\00_message\quest\q00030260.gmd,\quest\q00030260.arc,q00030260.arc,83,Lise
 0,,エリオット、落ち着いて！,"Elliot, calm down!",ui\00_message\quest\q00030260.gmd,\quest\q00030260.arc,q00030260.arc,84,Lise

--- a/English/splits/169.csv
+++ b/English/splits/169.csv
@@ -658,7 +658,9 @@ you just learned, check 《Tutorial》→
 《Job Roles》for tactics and duties.",ui\00_message\quest\q60000007.gmd,\quest\q60000007.arc,q60000007.arc,11,Hunter
 0,,"お前なら、より巨大な魔物へ挑むための
 試練も達成できるだろう
-さらなる挑戦を待っているぞ",You might even conquer trials to challenge larger fiends. Greater trials await,ui\00_message\quest\q60000007.gmd,\quest\q60000007.arc,q60000007.arc,12,Hunter
+さらなる挑戦を待っているぞ","You, ser, may have what it takes to overcome
+the trials necessary to fell even greater foes.
+I look forward to challenging you again.",ui\00_message\quest\q60000007.gmd,\quest\q60000007.arc,q60000007.arc,12,Hunter
 0,,お、訓練希望だな？　あらためてよろしくな！,"Oh, here for training? 
 Good to see you again!",ui\00_message\quest\q60000007.gmd,\quest\q60000007.arc,q60000007.arc,13,Renton
 0,,"ハンターの戦術試練を案内するよ
@@ -716,7 +718,9 @@ may obtain the 《Hunter's Mark.》",ui\00_message\quest\q60000007.gmd,\quest\q6
 review the knowledge you've gained so far.",ui\00_message\quest\q60000007.gmd,\quest\q60000007.arc,q60000007.arc,27,Wilson
 0,,"また立ちはだかる魔物が
 課題中にすべていなくなったら
-再度出直してくるがいい","If all fiends in the trial vanish, return and try again later",ui\00_message\quest\q60000007.gmd,\quest\q60000007.arc,q60000007.arc,28,Wilson
+再度出直してくるがいい","If more monsters appear to block you,
+or if they're gone before you're done,
+come back and try again.",ui\00_message\quest\q60000007.gmd,\quest\q60000007.arc,q60000007.arc,28,Wilson
 0,,"さ、《修練の祠》へ行くんだ
 案内人は神殿を出て左手を進めば
 崖の下にいるからさ","Now go to the Training Chapel.

--- a/English/splits/178.csv
+++ b/English/splits/178.csv
@@ -238,8 +238,8 @@ Ser Arisen?",ui\00_message\quest\q60300041.gmd,\quest\q60300041.arc,q60300041.ar
 目を覚ましたかの魔物を、覚者様は
 ふたたび闇へと葬ってくださいました
 そう、フェルヤナの地はあなたによって救われました","The ancient Evil Eye that infested this land—
-that awakened fiend was 
-returned to darkness by you, Ser Arisen. 
+that awakened fiend was duly returned
+to darkness by you, Ser Arisen. 
 Truly, you have saved the Feryana region.",ui\00_message\quest\q60300041.gmd,\quest\q60300041.arc,q60300041.arc,7,Nazik
 0,,"英霊は覚者様にその力を貸すために現れました
 それはあなたの戦いにおける強さだけではなく

--- a/English/splits/266.csv
+++ b/English/splits/266.csv
@@ -526,9 +526,8 @@ actually accomplish?",ui\00_message\quest\q00020050.gmd,\quest\q00020050.arc,q00
 0,,"というわけで、だ――
 俺が馴染みの覚者たちと一緒に
 侵食魔退治を引き受けるから","So, it's settled—
-I will take on the task of
-defeating the encroaching fiends
-with the Arisen I'm familiar with.",ui\00_message\quest\q00020060.gmd,\quest\q00020060.arc,q00020060.arc,2,Gurdolin,
+I, together with my usual group of Arisen,
+shall defeat the encroaching enemy.",ui\00_message\quest\q00020060.gmd,\quest\q00020060.arc,q00020060.arc,2,Gurdolin,
 0,,"セシリーの姿が見えないと不安になりますね
 またひとりでどこかへ行ってしまったのかも
 しれない――なんて","When Cecily is out of sight, it makes me 
@@ -996,7 +995,9 @@ may obtain the 《Sorcerer's Mark.》",ui\00_message\quest\q60000008.gmd,\quest\
 review the knowledge you've gained so far.",ui\00_message\quest\q60000008.gmd,\quest\q60000008.arc,q60000008.arc,29,Wilson,
 0,,"また立ちはだかる魔物が
 課題中にすべていなくなったら
-再度出直してくるがいい","If all fiends in the trial vanish, return and try again later",ui\00_message\quest\q60000008.gmd,\quest\q60000008.arc,q60000008.arc,30,Wilson,
+再度出直してくるがいい","If more monsters appear to block you,
+or if they're gone before you're done,
+come back and try again.",ui\00_message\quest\q60000008.gmd,\quest\q60000008.arc,q60000008.arc,30,Wilson,
 0,,"さあ、《修練の祠》へ行くんだ
 案内人は神殿を出て左手を進めば
 崖の上の祠内にいるよ","Now go to the Training Chapel.
@@ -1119,7 +1120,9 @@ may obtain the 《Element Archer's Mark.》",ui\00_message\quest\q60000009.gmd,\
 review the knowledge you've gained so far.",ui\00_message\quest\q60000009.gmd,\quest\q60000009.arc,q60000009.arc,31,Wilson,
 0,,"また立ちはだかる魔物が
 課題中にすべていなくなったら
-再度出直してくるがいい","If all fiends in the trial vanish, return and try again later",ui\00_message\quest\q60000009.gmd,\quest\q60000009.arc,q60000009.arc,32,Wilson,
+再度出直してくるがいい","If more monsters appear to block you,
+or if they're gone before you're done,
+come back and try again.",ui\00_message\quest\q60000009.gmd,\quest\q60000009.arc,q60000009.arc,32,Wilson,
 0,,"さあ、《修練の祠》へ行くんだ
 案内人は神殿を出て左手を進めば、崖の上さ","Now, go to the Training Chapel.
 The guide is on your left as you 
@@ -1222,7 +1225,9 @@ the 《Warrior's Mark.》",ui\00_message\quest\q60000010.gmd,\quest\q60000010.ar
 review the knowledge you've gained so far.",ui\00_message\quest\q60000010.gmd,\quest\q60000010.arc,q60000010.arc,30,Wilson,
 0,,"また立ちはだかる魔物が
 課題中にすべていなくなったら
-再度出直してくるがいい","If all fiends in the trial vanish, return and try again later",ui\00_message\quest\q60000010.gmd,\quest\q60000010.arc,q60000010.arc,31,Wilson,
+再度出直してくるがいい","If more monsters appear to block you,
+or if they're gone before you're done,
+come back and try again.",ui\00_message\quest\q60000010.gmd,\quest\q60000010.arc,q60000010.arc,31,Wilson,
 0,,"さあ、《修練の祠》へ行くんだ
 案内人は神殿を出て左手を進めば、崖の上さ","Now, go to the Training Chapel.
 The guide is on your left as you 

--- a/English/splits/267.csv
+++ b/English/splits/267.csv
@@ -94,7 +94,9 @@ the 《Alchemist's Mark.》",ui\00_message\quest\q60000011.gmd,\quest\q60000011.
 review the knowledge you've gained so far.",ui\00_message\quest\q60000011.gmd,\quest\q60000011.arc,q60000011.arc,37,Wilson
 0,,"また立ちはだかる魔物が
 課題中にすべていなくなったら
-再度出直してくるがいい","If all fiends in the trial vanish, return and try again later",ui\00_message\quest\q60000011.gmd,\quest\q60000011.arc,q60000011.arc,38,Wilson
+再度出直してくるがいい","If more monsters appear to block you,
+or if they're gone before you're done,
+come back and try again.",ui\00_message\quest\q60000011.gmd,\quest\q60000011.arc,q60000011.arc,38,Wilson
 0,,"さあ、《修練の祠》へ行くんだ
 案内人は神殿を出て左手を進めば
 崖の上の祠にいるよ","Now go to the Training Chapel.


### PR DESCRIPTION
魔物 (mamono) and other permutations of 魔- (non-game term) = sometimes used fiend. now more general, like monster, foe, or beast.
魔族 (mazoku) = prev. Demon type of enemy. now Fiend or abomination, abberation, or monstrosity.

Note: changed  "2nd Interrogation: Fiend Grasping a Key" to "Demonic Keyholder" in case something breaks in the future.