### PR TITLE
bitterblack various fixes

### DIFF
--- a/English/Fully Translated/103.csv
+++ b/English/Fully Translated/103.csv
@@ -634,58 +634,56 @@ to join and then come back.",ui\00_message\npc\base\n0710.gmd,\npc\n0710.arc,n07
 0,,"覚者様、黒呪の迷宮へようこそ
 ここは元いた場所とは隔絶された世界
 ――わたしはこの迷宮の案内人
-何か、ご用はありますか？","Welcome to Bitterblack Maze, Arisen. This is a
-world isolated from where you once were ――I am the
-guide of this maze. Do you have any business here?",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,0,Luca
+何か、ご用はありますか？","Welcome to Bitterblack Maze, Arisen.
+This is a world isolated from where you once were――
+I am the guide of this maze.
+Well, what is it you seek?",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,0,Luca
 0,,"覚者様、呪われし迷宮へようこそ
-わたしはこの迷宮の案内人","Arisen, welcome to the cursed Bitterblack Maze. I
-am the guide of this labyrinth.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,1,Luca
+わたしはこの迷宮の案内人","Arisen, welcome to the cursed Bitterblack Maze.
+I am the guide of this labyrinth.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,1,Luca
 0,,"本来は交わることのない世界の交錯により
 姿を現してしまった迷宮","This maze appeared as a result of the collision
 of worlds that should never have intersected.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,2,Luca
 0,,"この先にある入口がどこへと続くのかは
-わたしにもわかりません","I also don't know where the entrance ahead leads
-to.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,3,Luca
+わたしにもわかりません","Where the entrance ahead leads,
+I cannot tell you.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,3,Luca
 0,,"入り江に響くのは数えきれない魔物たちの声
-そして覚者たちの叫び――","The wind is blowing—This is a tailwind—oh, I can
-feel it.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,4,Luca
+そして覚者たちの叫び――","The bay echoes the cries of countless creatures,
+even those of Arisen...",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,4,Luca
 0,,"仲間と共に挑むか、戦徒を従え進むか
-全てはあなた次第です","While dealing with the enemy's offensive, we must
-also explore the ways to defeat the ""Evil Dragon.""
-In the face of the enemy's offensive, it is
-necessary to not only deal with it but also
-explore ways to defeat the ""Evil Dragon.""",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,5,Luca
+全てはあなた次第です","Whether you choose to face the challenge alone,
+or should you choose to lead your own army
+with comrades, the choice is entirely yours.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,5,Luca
 0,,"わたしはこの場所で、できる限りの
-手助けをいたしましょう","I will provide as much assistance as possible in
-this place.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,6,Luca
+手助けをいたしましょう","I will provide as much assistance as I am able.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,6,Luca
 0,,"姿形は違えど、あなたはあなた――
 その存在に違いはございません
 ただ、今までの全てを
-置き去りにした状態であるだけです","Although the appearance may be different, you are
-still you - There is no difference in your
-existence. You are just in a state where you have
-left behind everything that has come before.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,7,Luca
+置き去りにした状態であるだけです","Although your appearance has changed,
+you are still you. Your essence remains the same.
+You are simply in a state where you have left
+everything behind in the past.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,7,Luca
 0,,"この《黒呪の迷宮》は生きる島
 島の蠢きにより強力な宝物が生み出されます
 覚者様のお目に適う物があれば
-わたしが協力いたしましょう","This ""Bitterblack Maze"" is a living island.
-Powerful treasures are created by the island's
-movements. If there is something suitable for the
-Arisen to see, I will assist you.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,8,Luca
+わたしが協力いたしましょう","This ""Bitterblack Maze"" is a living island
+from which powerful treasures are born.
+If there is anything that suits your taste,
+Arisen, it will be my honor to assist you.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,8,Luca
 0,,"物品の本来の姿を取り戻す《レアアイテムの鑑定》
 そして特定の効果を封じる《黒呪装具の効果封印》
-どちらもわたしに心得がございます","Unlocking the true form of an item with Rare Item
-Appraisal, and sealing specific effects with
-Bitterblack Equipment Effect Seal. I am
-knowledgeable in both.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,9,Luca
-0,,どうぞご随意に――,Please feel free to help yourself――,ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,10,Luca
+どちらもわたしに心得がございます","Unlock the true form of an item
+with Rare Item Appraisal, and sealing specific effects
+with Bitterblack Equipment Effect Seal.
+I am knowledgeable in both ways.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,9,Luca
+0,,どうぞご随意に――,Feel free to do as you wish――,ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,10,Luca
 0,,"この地で見つけた品を
 レスタニアに持ち帰るには
 《黒呪アイテムの持ち帰り》での選択が必要です
-何を持ち帰るか、慎重にご判断ください","To bring items found here back to Lestania, you
-will need to make a selection at ""Bitterblack Item
-Takeaway"".
-Please be judicious in what you bring back!",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,11,Luca
+何を持ち帰るか、慎重にご判断ください","To bring items found here back to Lestania,
+you will need to make a selection at
+""Bitterblack Item Takeaway"".
+Remain judicious in what you bring back.",ui\00_message\npc\base\n0715.gmd,\npc\n0715.arc,n0715.arc,11,Luca
 0,,"白竜様よりお預かりした加護――
 三たび、あなたが立ち上がるための
 《復活力》としてお渡しいたします","The blessing entrusted to you by Lord White

--- a/English/Fully Translated/258.csv
+++ b/English/Fully Translated/258.csv
@@ -45,8 +45,8 @@ and cannot earn any more.",ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_c
 (<VAL>/<VAL JP>)",ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,227,
 228,syslog_jp_possession_max_pawn,<NAME PAWN>のジョブポイントが最大に達したため、これ以上獲得できません,"<NAME PAWN> has reached the maximum amount of Job
 Points and cannot earn any more.",ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,228,
-329,syslog_kt_get,<UNTN KT>を<VAL><UNIT KT>、入手しました,<UNTN KT> <UNIT KT><VAL> obtained.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,329,
-330,syslog_kt_lost,<UNTN KT>を<VAL><UNIT KT>、消費しました,<UNTN KT> <UNIT KT><VAL> spent.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,330,
+329,syslog_kt_get,<UNTN KT>を<VAL><UNIT KT>、入手しました,<VAL> <UNIT KT> of <UNTN KT>s obtained.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,329,
+330,syslog_kt_lost,<UNTN KT>を<VAL><UNIT KT>、消費しました,<VAL> <UNIT KT> of <UNTN KT>s spent.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,330,
 335,syslog_kt_possession_max,<UNTN KT>が最大まで補充されました,<UNTN KT> has been replenished to the maximum.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,335,
 125,syslog_levelup_job_me,<NAME PLAYER>が<VAL LV>になりました,<NAME PLAYER> has reached <VAL LV>.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,125,
 127,syslog_levelup_job_pawn,<NAME PAWN>が<VAL LV>になりました,<NAME PAWN> has reached <VAL LV>.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,127,
@@ -238,9 +238,9 @@ Matching conditions for Secondary Purpose <<NAME ETC>
 374,syslog_r_possession_max,<UNTN R>が最大に達したため、これ以上獲得できません,"You have reached the maximum 
 amount of <UNTN R>
 and cannot earn any more.",ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,374,
-325,syslog_rdm_get,<UNTN RDM>を<VAL><UNIT RDM>、入手しました,<UNTN RDM> <UNIT RDM><VAL> obtained.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,325,
+325,syslog_rdm_get,<UNTN RDM>を<VAL><UNIT RDM>、入手しました,<VAL> <UNIT RDM> of <UNTN RDM>s obtained.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,325,
 364,syslog_rdm_get_ex,<UNTN RDM>を<VAL>(+<VAL>)<UNIT RDM>、入手しました,<VAL>(+<VAL>)<UNIT RDM> obtained from <UNTN RDM>,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,364,
-328,syslog_rdm_lost,<UNTN RDM>を<VAL><UNIT RDM>、消費しました,<UNTN RDM> <UNIT RDM><VAL> spent.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,328,
+328,syslog_rdm_lost,<UNTN RDM>を<VAL><UNIT RDM>、消費しました,<VAL> <UNIT RDM> of <UNTN RDM>s spent.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,328,
 192,syslog_receipt_mailitem,メールで特典アイテムをお受け取りください,"Please check your mail to
 receive the items.",ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,192,
 284,syslog_release_area_spot,<VAL>の<VAL>が解放されました,<VAL>'s <VAL> unlocked.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,284,
@@ -267,9 +267,9 @@ will be lost.",ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,300,
 377,syslog_rp_possession_max,<UNTN RP>が最大に達したため、これ以上獲得できません,"You have reached the maximum 
 amount of <UNTN RP>
 and cannot earn any more.",ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,377,
-324,syslog_sdm_get,<UNTN SDM>を<VAL><UNIT SDM>、入手しました,<UNTN SDM> <UNIT SDM><VAL> obtained.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,324,
+324,syslog_sdm_get,<UNTN SDM>を<VAL><UNIT SDM>、入手しました,<VAL> <UNIT SDM> of <UNTN SDM>s obtained.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,324,
 363,syslog_sdm_get_ex,<UNTN SDM>を<VAL>(+<VAL>)<UNIT SDM>、入手しました,Retrieved <VAL>(+<VAL>)<UNIT SDM> at <UNTN SDM>,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,363,
-327,syslog_sdm_lost,<UNTN SDM>を<VAL><UNIT SDM>、消費しました,<UNTN SDM> <UNIT SDM><VAL> spent.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,327,
+327,syslog_sdm_lost,<UNTN SDM>を<VAL><UNIT SDM>、消費しました,<VAL> <UNIT SDM> of <UNTN SDM>s spent.,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,327,
 197,syslog_silvertichet_lost,シルバーチケットを<VAL>枚、消費しました（所持数：<VAL>）,Silver Tickets x<VAL> spent (have: <VAL>).,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,197,
 190,syslog_silvertickets_get,シルバーチケットを<VAL>枚、入手しました（所持数：<VAL>）,Silver Tickets x<VAL> (have: <VAL>).,ui\00_message\ui\system_log.gmd,\ui\gui_cmn.arc,gui_cmn.arc,190,
 181,syslog_soloquest_lock,現在クエストを受注する事は出来ません。謁見の間でレオに話しかけてメインクエストを進行してください,"You cannot accept personal quests at the moment.

--- a/English/splits/086.csv
+++ b/English/splits/086.csv
@@ -313,8 +313,8 @@ Force gathers within Firefall Mountain.",ui\00_message\loading\loading_message_0
 居ないことだけは確かなようだ","Led by the Myrmidon Luca, we arrive at an inlet
 on the remote island.
 The sky is always filled with thick dark clouds,
-so much so that it is impossible to even determine
-the current time.
+so much so that it is impossible to even
+determine the current time.
 The treacherous cliffs and desolate appearance
 suggest that there are no living beings present.",ui\00_message\loading\loading_message_024.gmd,\ui\00_message\loading\loading_message_024.arc,loading_message_024.arc,0,
 0,MANDRAGORA_SPECIES_INFO_1,"産まれたばかりのマンドラゴラ

--- a/English/splits/256.csv
+++ b/English/splits/256.csv
@@ -489,16 +489,16 @@ at the last camp?
 the Weakness debilitation.</COL>",ui\00_message\ui\retry.gmd,\ui\uGUIRetrySelect.arc,uGUIRetrySelect.arc,12,
 16,RETRY_MSG_DIALOG_PENALTY_BBI,"に戻りますか？
 状態異常【弱化】が発生しませんが
-<COL AA1414>アイテムバッグの中身がすべて消失します</COL>","Do you want to return? The condition [Weaken]
-will not occur, but
-<COL AA1414>all contents of the item bag are
-lost</COL>.",ui\00_message\ui\retry.gmd,\ui\uGUIRetry.arc,uGUIRetry.arc,16,
+<COL AA1414>アイテムバッグの中身がすべて消失します</COL>","
+Do you wish to return there?
+The [Weakness] condition will not occur,
+but <COL AA1414>all contents of the item bag will be lost</COL>.",ui\00_message\ui\retry.gmd,\ui\uGUIRetry.arc,uGUIRetry.arc,16,
 16,RETRY_MSG_DIALOG_PENALTY_BBI,"に戻りますか？
 状態異常【弱化】が発生しませんが
-<COL AA1414>アイテムバッグの中身がすべて消失します</COL>","Do you want to return? The condition [Weaken]
-will not occur, but
-<COL AA1414>all contents of the item bag are
-lost</COL>.",ui\00_message\ui\retry.gmd,\ui\uGUIRetrySelect.arc,uGUIRetrySelect.arc,16,
+<COL AA1414>アイテムバッグの中身がすべて消失します</COL>","
+Do you wish to return there?
+The [Weakness] condition will not occur,
+but <COL AA1414>all contents of the item bag will be lost</COL>.",ui\00_message\ui\retry.gmd,\ui\uGUIRetrySelect.arc,uGUIRetrySelect.arc,16,
 14,RETRY_MSG_DIALOG_RIM,"<COL FFFF00>リム</COL>を<VAL RIM>消費して救出します
 よろしいですか？","Are you sure you want to resurrect by using
 <VAL RIM> <COL FFFF00>Rift Crystals</COL>?",ui\00_message\ui\retry.gmd,\ui\uGUIRetry.arc,uGUIRetry.arc,14,
@@ -536,13 +536,11 @@ Weakness debilitation.</COL>",ui\00_message\ui\retry.gmd,\ui\uGUIRetry.arc,uGUIR
 <COL AA1414>You will be afflicted with the
 Weakness debilitation.</COL>",ui\00_message\ui\retry.gmd,\ui\uGUIRetrySelect.arc,uGUIRetrySelect.arc,3,
 15,RETRY_MSG_PENALTY_EXP_BBI,"状態異常【弱化】が発生しませんが
-<COL AA1414>アイテムバッグの中身がすべて消失します</COL>","The condition [Weaken] will not occur, but
-<COL AA1414>all contents of the item bag are
-lost</COL>.",ui\00_message\ui\retry.gmd,\ui\uGUIRetry.arc,uGUIRetry.arc,15,
+<COL AA1414>アイテムバッグの中身がすべて消失します</COL>","The [Weakness] condition will not occur,
+but <COL AA1414>all contents of the item bag will be lost</COL>.",ui\00_message\ui\retry.gmd,\ui\uGUIRetry.arc,uGUIRetry.arc,15,
 15,RETRY_MSG_PENALTY_EXP_BBI,"状態異常【弱化】が発生しませんが
-<COL AA1414>アイテムバッグの中身がすべて消失します</COL>","The condition [Weaken] will not occur, but
-<COL AA1414>all contents of the item bag are
-lost</COL>.",ui\00_message\ui\retry.gmd,\ui\uGUIRetrySelect.arc,uGUIRetrySelect.arc,15,
+<COL AA1414>アイテムバッグの中身がすべて消失します</COL>","The [Weakness] condition will not occur,
+but <COL AA1414>all contents of the item bag will be lost</COL>.",ui\00_message\ui\retry.gmd,\ui\uGUIRetrySelect.arc,uGUIRetrySelect.arc,15,
 11,RETRY_MSG_REVIVE_MENU_PENALTY,直前の拠点から再開,Revive at Last Camp,ui\00_message\ui\retry.gmd,\ui\uGUIRetry.arc,uGUIRetry.arc,11,
 11,RETRY_MSG_REVIVE_MENU_PENALTY,直前の拠点から再開,Revive at Last Camp,ui\00_message\ui\retry.gmd,\ui\uGUIRetrySelect.arc,uGUIRetrySelect.arc,11,
 13,RETRY_MSG_REVIVE_MENU_RIM,リムを使用して復活,Revive with Rift Crystals,ui\00_message\ui\retry.gmd,\ui\uGUIRetry.arc,uGUIRetry.arc,13,


### PR DESCRIPTION
fixed tags when receiving marks in chat, luca's dialogues, choose revival screen, spot info linebreak.

<img width="334" height="72" alt="image" src="https://github.com/user-attachments/assets/ca753257-2c4c-42b4-b8b3-d1156515a83c" />


Note: somehow, this line: 
```
"While dealing with the enemy's offensive, we must
also explore the ways to defeat the ""Evil Dragon.""
In the face of the enemy's offensive, it is
necessary to not only deal with it but also
explore ways to defeat the ""Evil Dragon."""
```
got jumbled into Luca's dialogue. I'm not sure how.

Also this: 
```
"The wind is blowing—This is a tailwind—oh, I can
feel it."
```
XD silly AI